### PR TITLE
聖遺物カードにコンテキストメニュー機能を追加

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -320,3 +320,45 @@ body {
   font-size: 0.8rem;
   color: var(--text-sub);
 }
+
+/* ── 聖遺物画像クリック可能スタイル ─────── */
+.artifact-img-clickable {
+  cursor: pointer;
+  transition: box-shadow 0.15s, border-color 0.15s;
+}
+
+.artifact-img-clickable:hover {
+  border-color: var(--gold);
+  box-shadow: 0 0 8px rgba(200, 163, 90, 0.4);
+}
+
+/* ── コンテキストメニュー ────────────────── */
+.context-menu {
+  position: fixed;
+  z-index: 1000;
+  background: var(--bg-ctrl);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
+  min-width: 12rem;
+  overflow: hidden;
+}
+
+.context-menu-item {
+  display: block;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  text-align: left;
+  font-size: 0.85rem;
+  color: var(--text-main);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+}
+
+.context-menu-item:hover {
+  background: var(--bg-card-hover);
+  color: var(--gold-light);
+}

--- a/webapp/src/app/page.tsx
+++ b/webapp/src/app/page.tsx
@@ -137,7 +137,14 @@ export default function HomePage() {
           {/* ── カードグリッド ── */}
           <div className="card-grid">
             {displayed.map((entry, i) => (
-              <ArtifactCard key={i} rank={i + 1} entry={entry} scoreType={scoreType} />
+              <ArtifactCard
+                key={i}
+                rank={i + 1}
+                entry={entry}
+                scoreType={scoreType}
+                onFilterBySet={setFilterSet}
+                onFilterBySlot={setFilterSlot}
+              />
             ))}
           </div>
         </>

--- a/webapp/src/components/ArtifactCard.tsx
+++ b/webapp/src/components/ArtifactCard.tsx
@@ -1,11 +1,18 @@
-import type { RankedArtifact, ScoreTypeName } from '@/lib/types'
+'use client'
+
+import { useState } from 'react'
+import type { RankedArtifact, ScoreTypeName, ArtifactSlotKey } from '@/lib/types'
 import { ARTIFACT_SET_NAMES, SLOT_NAMES, STAT_NAMES, PERCENT_STATS, MAIN_STAT_NAMES, getMainStatValue } from '@/lib/constants'
 import { decomposeRolls } from '@/lib/scoring'
+import { getContextMenuItems } from '@/lib/contextMenu'
+import ContextMenu from './ContextMenu'
 
 interface ArtifactCardProps {
   rank: number
   entry: RankedArtifact
   scoreType: ScoreTypeName
+  onFilterBySet?: (setKey: string) => void
+  onFilterBySlot?: (slotKey: ArtifactSlotKey) => void
 }
 
 /** メインスコアの値に応じた色クラスを返す */
@@ -40,7 +47,13 @@ function formatSubstat(
   return { label, valueStr, rollDetail }
 }
 
-export default function ArtifactCard({ rank, entry, scoreType }: ArtifactCardProps) {
+/** コンテキストメニューの状態 */
+interface MenuState {
+  x: number
+  y: number
+}
+
+export default function ArtifactCard({ rank, entry, scoreType, onFilterBySet, onFilterBySlot }: ArtifactCardProps) {
   const { artifact, cvScore, allScores, rollCounts } = entry
   const { setKey, slotKey, level, rarity, location, substats, mainStatKey } = artifact
 
@@ -55,6 +68,21 @@ export default function ArtifactCard({ rank, entry, scoreType }: ArtifactCardPro
   const mainScore = allScores[scoreType]
   const showCvSub = scoreType !== 'CV'
 
+  const [menuState, setMenuState] = useState<MenuState | null>(null)
+
+  // フィルタコールバックが両方存在する場合のみコンテキストメニューを有効化
+  const canFilter = !!onFilterBySet && !!onFilterBySlot
+
+  function handleImageClick(e: React.MouseEvent) {
+    if (!canFilter) return
+    e.stopPropagation()
+    setMenuState({ x: e.clientX, y: e.clientY })
+  }
+
+  const menuItems = canFilter
+    ? getContextMenuItems(setKey, slotKey, onFilterBySet!, onFilterBySlot!)
+    : []
+
   return (
     <div className="artifact-card">
       {/* ランク番号 */}
@@ -62,8 +90,12 @@ export default function ArtifactCard({ rank, entry, scoreType }: ArtifactCardPro
 
       {/* 上部: 聖遺物画像 + セット情報 + キャラアイコン */}
       <div className="card-header">
-        {/* 聖遺物画像 */}
-        <div className="artifact-img-wrap">
+        {/* 聖遺物画像（クリックでフィルタメニュー） */}
+        <div
+          className={`artifact-img-wrap${canFilter ? ' artifact-img-clickable' : ''}`}
+          onClick={handleImageClick}
+          title={canFilter ? 'クリックしてフィルタ' : undefined}
+        >
           <img
             src={artifactImgSrc}
             alt={`${setName} ${slotName}`}
@@ -127,6 +159,16 @@ export default function ArtifactCard({ rank, entry, scoreType }: ArtifactCardPro
           )
         })}
       </div>
+
+      {/* コンテキストメニュー */}
+      {menuState && (
+        <ContextMenu
+          x={menuState.x}
+          y={menuState.y}
+          items={menuItems}
+          onClose={() => setMenuState(null)}
+        />
+      )}
     </div>
   )
 }

--- a/webapp/src/components/ContextMenu.tsx
+++ b/webapp/src/components/ContextMenu.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import type { ContextMenuItem } from '@/lib/contextMenu'
+
+interface ContextMenuProps {
+  x: number
+  y: number
+  items: ContextMenuItem[]
+  onClose: () => void
+}
+
+/** 聖遺物アイコンクリック時に表示するコンテキストメニュー */
+export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // メニュー外クリックで閉じる
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [onClose])
+
+  // Escape キーで閉じる
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  return (
+    <div
+      ref={menuRef}
+      className="context-menu"
+      style={{ left: x, top: y }}
+    >
+      {items.map((item, i) => (
+        <button
+          key={i}
+          className="context-menu-item"
+          onClick={() => {
+            item.onClick()
+            onClose()
+          }}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/webapp/src/lib/__tests__/contextMenu.test.ts
+++ b/webapp/src/lib/__tests__/contextMenu.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getContextMenuItems } from '@/lib/contextMenu'
+import type { ArtifactSlotKey } from '@/lib/types'
+
+describe('getContextMenuItems', () => {
+  it('2つのメニュー項目を返す', () => {
+    const items = getContextMenuItems('GladiatorsFinale', 'flower', vi.fn(), vi.fn())
+    expect(items).toHaveLength(2)
+  })
+
+  it('セットフィルタ項目のラベルにセット名が含まれる', () => {
+    const items = getContextMenuItems('GladiatorsFinale', 'flower', vi.fn(), vi.fn())
+    const setItem = items[0]
+    expect(setItem.label).toContain('セット')
+  })
+
+  it('部位フィルタ項目のラベルに部位名が含まれる', () => {
+    const items = getContextMenuItems('GladiatorsFinale', 'flower', vi.fn(), vi.fn())
+    const slotItem = items[1]
+    expect(slotItem.label).toContain('部位')
+  })
+
+  it('セットフィルタ項目をクリックすると onFilterBySet が呼ばれる', () => {
+    const onFilterBySet = vi.fn()
+    const onFilterBySlot = vi.fn()
+    const items = getContextMenuItems('GladiatorsFinale', 'flower', onFilterBySet, onFilterBySlot)
+
+    items[0].onClick()
+
+    expect(onFilterBySet).toHaveBeenCalledOnce()
+    expect(onFilterBySet).toHaveBeenCalledWith('GladiatorsFinale')
+    expect(onFilterBySlot).not.toHaveBeenCalled()
+  })
+
+  it('部位フィルタ項目をクリックすると onFilterBySlot が呼ばれる', () => {
+    const onFilterBySet = vi.fn()
+    const onFilterBySlot = vi.fn()
+    const items = getContextMenuItems('GladiatorsFinale', 'flower', onFilterBySet, onFilterBySlot)
+
+    items[1].onClick()
+
+    expect(onFilterBySlot).toHaveBeenCalledOnce()
+    expect(onFilterBySlot).toHaveBeenCalledWith('flower' as ArtifactSlotKey)
+    expect(onFilterBySet).not.toHaveBeenCalled()
+  })
+
+  it('異なるセットキーと部位キーでも正しく動作する', () => {
+    const onFilterBySet = vi.fn()
+    const onFilterBySlot = vi.fn()
+    const items = getContextMenuItems('NoblesseOblige', 'circlet', onFilterBySet, onFilterBySlot)
+
+    items[0].onClick()
+    items[1].onClick()
+
+    expect(onFilterBySet).toHaveBeenCalledWith('NoblesseOblige')
+    expect(onFilterBySlot).toHaveBeenCalledWith('circlet' as ArtifactSlotKey)
+  })
+})

--- a/webapp/src/lib/contextMenu.ts
+++ b/webapp/src/lib/contextMenu.ts
@@ -1,0 +1,28 @@
+import type { ArtifactSlotKey } from './types'
+import { ARTIFACT_SET_NAMES, SLOT_NAMES } from './constants'
+
+export interface ContextMenuItem {
+  label: string
+  onClick: () => void
+}
+
+/** 聖遺物アイコンクリック時のコンテキストメニュー項目を生成する */
+export function getContextMenuItems(
+  setKey: string,
+  slotKey: ArtifactSlotKey,
+  onFilterBySet: (setKey: string) => void,
+  onFilterBySlot: (slotKey: ArtifactSlotKey) => void,
+): ContextMenuItem[] {
+  const setName = ARTIFACT_SET_NAMES[setKey] ?? setKey
+  const slotName = SLOT_NAMES[slotKey] ?? slotKey
+  return [
+    {
+      label: `セット: ${setName}`,
+      onClick: () => onFilterBySet(setKey),
+    },
+    {
+      label: `部位: ${slotName}`,
+      onClick: () => onFilterBySlot(slotKey),
+    },
+  ]
+}


### PR DESCRIPTION
## 概要
聖遺物画像をクリックして、セット・部位でフィルタリングできるコンテキストメニューを実装しました。ユーザーは聖遺物アイコンをクリックすることで、そのセットまたは部位のみを表示するようにフィルタリングできます。

## 変更内容
- **ContextMenu.tsx**: 位置指定のコンテキストメニューコンポーネント（Escapeキーと外部クリック対応）
- **contextMenu.ts**: セット・部位フィルタメニュー項目を生成するユーティリティ関数
- **ArtifactCard.tsx**: `'use client'`化、クリックハンドラー、フィルターコールバック実装
- **globals.css**: メニューと画像ホバー時のスタイル追加
- **contextMenu.test.ts**: 完全なテストカバレッジ（6つのテストケース）

## テスト計画
- [x] 聖遺物画像ホバー時のスタイル確認（枠線と陰影）
- [x] コンテキストメニュー表示・位置確認
- [x] セットフィルタ項目クリック→`onFilterBySet`が正しい引数で呼ばれる
- [x] 部位フィルタ項目クリック→`onFilterBySlot`が正しい引数で呼ばれる
- [x] メニュー外クリックで閉じる動作確認
- [x] Escapeキーでメニューが閉じる

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)