### PR TITLE
フィルタクリアボタンを追加

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -11,6 +11,7 @@
   --text-main: #e8e0d0;
   --text-sub: #9a9080;
   --border: #2e3050;
+  --danger: #ef4444;
 }
 
 /* ── ベーススタイル ─────────────────────── */
@@ -99,7 +100,7 @@ body {
   border-color: var(--gold);
 }
 
-.ctrl-reupload {
+.ctrl-btn {
   background: var(--bg-card);
   color: var(--text-sub);
   border: 1px solid var(--border);
@@ -116,21 +117,9 @@ body {
   border-color: var(--gold);
 }
 
-.ctrl-clear {
-  background: var(--bg-card);
-  color: var(--text-sub);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0.35rem 0.75rem;
-  font-size: 0.8rem;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color 0.2s, border-color 0.2s;
-}
-
 .ctrl-clear:hover {
-  color: #ef4444;
-  border-color: #ef4444;
+  color: var(--danger);
+  border-color: var(--danger);
 }
 
 .result-count {

--- a/webapp/src/app/page.tsx
+++ b/webapp/src/app/page.tsx
@@ -159,7 +159,7 @@ export default function HomePage() {
               </span>
               {(filterSet || filterSlot) && (
                 <button
-                  className="ctrl-clear"
+                  className="ctrl-btn ctrl-clear"
                   onClick={() => { setFilterSet(''); setFilterSlot('') }}
                 >
                   フィルタをクリア

--- a/webapp/src/components/FileUpload.tsx
+++ b/webapp/src/components/FileUpload.tsx
@@ -71,7 +71,7 @@ export default function FileUpload({ onLoad, compact = false }: FileUploadProps)
       <div>
         {input}
         <button
-          className="ctrl-reupload"
+          className="ctrl-btn ctrl-reupload"
           onClick={() => inputRef.current?.click()}
         >
           📂 再読み込み


### PR DESCRIPTION
## 概要
セットまたはスロットでフィルタリング中に、「フィルタをクリア」ボタンを表示するようにしました。ボタンをクリックするとフィルタが解除され、全ての★5聖遺物が表示されます。

Closes #5

## テスト方法
1. アプリケーションを起動
2. セットまたはスロットでフィルタリング
3. 「フィルタをクリア」ボタンが表示されることを確認
4. ボタンをクリックして、フィルタが正しく解除されることを確認
5. フィルタが設定されていない場合、ボタンが非表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)