### PR TITLE
fix: improve text color contrast to meet WCAG AA standard

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -9,7 +9,7 @@
   --gold: #c8a35a;
   --gold-light: #e8c880;
   --text-main: #e8e0d0;
-  --text-sub: #9a9080;
+  --text-sub: #b0a898;
   --border: #2e3050;
   --danger: #ef4444;
 }
@@ -577,7 +577,7 @@ body {
 }
 
 .substat-rolls {
-  color: #555870;
+  color: #7a7d96;
   font-size: 0.7rem;
   padding-left: 0.25rem;
   white-space: nowrap;


### PR DESCRIPTION
WCAG AAのコントラスト比基準（4.5:1）を満たすため、CSSカラー変数を調整しました。

- `--text-sub`: `#9a9080` → `#b0a898`
- `.substat-rolls`: `#555870` → `#7a7d96`

Closes #26

Generated with [Claude Code](https://claude.ai/code)