### PR TITLE
feat(claude): add claude-code-templates for frontend and dev workflow

### DIFF
--- a/.claude/agents/frontend-developer.md
+++ b/.claude/agents/frontend-developer.md
@@ -1,0 +1,72 @@
+---
+name: frontend-developer
+description: React/Next.js フロントエンド開発専門家。UI コンポーネント・パフォーマンス最適化・アクセシビリティ実装に特化。コンポーネント設計・レビュー・リファクタリングの依頼時に使用する。
+color: blue
+---
+
+# Frontend Developer Agent
+
+React と Next.js を用いたフロントエンド開発の専門エージェントです。
+
+## 参照ドキュメント
+
+作業開始前に必ず以下を読み込むこと:
+- `docs/dev/component_design.md` — コンポーネント設計・フィルタ・スコア色分け
+- `CLAUDE.md` — プロジェクト規約
+
+## 専門領域
+
+### Next.js App Router
+- Server Components と Client Components の適切な分離
+- `use client` の最小化（必要な場合のみ使用）
+- データフェッチは Server Component で行う
+- `next/image` を使用した画像最適化（`BASE_PATH` プレフィックスを必ず付与）
+- Static Export（`output: "export"`）との互換性確保
+
+### React 19
+- `useState` / `useEffect` の最小化
+- Suspense と Error Boundary の適切な使用
+- コンポーネントの再レンダリング最適化
+- `useMemo` / `useCallback` は計測に基づいて使用
+
+### Tailwind CSS 4
+- ユーティリティクラスの一貫した使用
+- レスポンシブデザイン（モバイルファースト）
+- `docs/dev/component_design.md` のスコア色分け規約遵守
+
+### TypeScript
+- 厳格な型付け（`any` 使用禁止）
+- Props インターフェースの明示的定義
+- ユニオン型・ジェネリクスの活用
+
+## コンポーネント設計原則
+
+1. **単一責任**: 1 コンポーネント = 1 責務
+2. **最小化**: 必要最小限の状態管理
+3. **再利用性**: 汎用コンポーネントは `components/ui/` に配置
+4. **テスタビリティ**: ロジックは `lib/` に分離してテスト容易にする
+
+## パフォーマンスチェックリスト
+
+- [ ] 不要な `use client` がないか
+- [ ] 画像に `next/image` を使用しているか
+- [ ] リストに適切な `key` があるか
+- [ ] 重いコンポーネントに `Suspense` を使用しているか
+- [ ] `BASE_PATH` を画像パスに付与しているか
+
+## アクセシビリティ
+
+- セマンティック HTML を使用する（`div` より `button`, `nav`, `main` 等）
+- `aria-label` を適切に設定する
+- キーボードナビゲーションを確保する
+- カラーコントラスト比を確認する（WCAG 2.1 AA 基準）
+
+## コードレビュー観点
+
+コンポーネントをレビューする際は以下を確認:
+
+1. Server / Client Component の分離が適切か
+2. Tailwind クラスがスコア色分け規約に従っているか（`component_design.md` 参照）
+3. TypeScript 型が厳格に定義されているか
+4. `BASE_PATH` を使用した画像パスが正しいか
+5. モバイル・デスクトップ両方でのレイアウトが適切か

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,60 @@
 {
   "permissions": {
     "allow": [
-      "Bash(python3:*)"
+      "Bash(python3:*)",
+      "Bash(npm run lint*)",
+      "Bash(npm run test*)",
+      "Bash(npm run build*)",
+      "Bash(npm run typecheck*)",
+      "Bash(npm run dev*)",
+      "Bash(npm install*)",
+      "Bash(npm ci*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git push*)",
+      "Bash(git pull*)",
+      "Bash(git checkout*)",
+      "Bash(git branch*)",
+      "Bash(git log*)",
+      "Bash(git fetch*)",
+      "Bash(git stash*)",
+      "Bash(git merge*)",
+      "Bash(git rebase*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"\nimport json, sys, re\ntry:\n    data = json.load(sys.stdin)\n    cmd = data.get('command', '')\n    if 'git commit' in cmd:\n        msg_match = re.search(r'-m\\s+[\\\"\\']([^\\\"\\']+)[\\\"\\']', cmd)\n        if msg_match:\n            msg = msg_match.group(1)\n            pattern = r'^(feat|fix|docs|style|refactor|test|chore|ci|perf|revert)(\\([a-z][a-z0-9-]*\\))?: .{1,72}$'\n            if not re.match(pattern, msg):\n                print(f'ERROR: Commit message does not follow Conventional Commits format.', file=sys.stderr)\n                print(f'Expected: type(scope): description', file=sys.stderr)\n                print(f'Got: {msg}', file=sys.stderr)\n                sys.exit(1)\nexcept Exception:\n    pass\n\""
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"\nimport json, sys, os, re\ntry:\n    data = json.load(sys.stdin)\n    path = data.get('file_path', '')\n    if re.search(r'webapp/src/(?!.*__tests__).*\\.tsx?$', path):\n        base = re.sub(r'webapp/src/', 'webapp/src/lib/__tests__/', path)\n        base = re.sub(r'\\.(tsx?)$', '.test.\\\\1', base)\n        alt = re.sub(r'webapp/src/(.+?)\\.(tsx?)$', r'webapp/src/lib/__tests__/\\1.test.\\2', path)\n        if not os.path.exists(path.replace('/src/', '/src/lib/__tests__/').replace('.ts', '.test.ts').replace('.tsx', '.test.tsx')):\n            dir_name = os.path.dirname(path)\n            test_dir = os.path.join(os.path.dirname(os.path.dirname(path)), 'lib', '__tests__')\n            base_name = os.path.basename(path)\n            test_name = re.sub(r'\\.(tsx?)$', r'.test.\\1', base_name)\n            test_path = os.path.join(test_dir, test_name)\n            if 'lib/' in path and not os.path.exists(test_path):\n                print(f'WARNING: No test file found for {os.path.basename(path)}.', file=sys.stderr)\n                print(f'TDD required: create {test_path} first.', file=sys.stderr)\nexcept Exception:\n    pass\n\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"\nimport json, sys, os, subprocess, re\ntry:\n    data = json.load(sys.stdin)\n    path = data.get('file_path', '')\n    if re.search(r'webapp/src/.*\\.(tsx?|js)$', path):\n        result = subprocess.run(\n            ['npm', 'test', '--', '--run'],\n            cwd=os.path.join(os.path.dirname(path).split('webapp')[0], 'webapp'),\n            capture_output=True, text=True, timeout=60\n        )\n        if result.returncode != 0:\n            print('Tests failed after changes:', file=sys.stderr)\n            print(result.stdout[-2000:], file=sys.stderr)\nexcept Exception:\n    pass\n\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/commit-smart/SKILL.md
+++ b/.claude/skills/commit-smart/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: commit-smart
+description: 'git diff を解析して Conventional Commits 形式のコミットメッセージを自動生成するスキル。コミット前に /commit-smart を実行する。'
+---
+
+# Commit Smart スキル
+
+`git diff` を解析し、プロジェクトの規約に従った Conventional Commits 形式のコミットメッセージを自動生成します。
+
+## 使い方
+
+コミットしたい変更をステージングした後、このスキルを実行します。
+
+## 手順
+
+### ステップ 1: 変更内容を把握する
+
+```bash
+git status
+git diff --staged
+```
+
+ステージングされていない場合:
+```bash
+git diff HEAD
+```
+
+### ステップ 2: コミットメッセージを生成する
+
+変更内容を分析して以下の規則に従いメッセージを生成:
+
+**フォーマット:** `<type>(<scope>): <description>`
+
+**type の選択基準:**
+| type | 用途 |
+|---|---|
+| `feat` | 新機能の追加 |
+| `fix` | バグ修正 |
+| `docs` | ドキュメントのみの変更 |
+| `style` | コードの意味に影響しない変更（フォーマット等） |
+| `refactor` | バグ修正・機能追加を伴わないリファクタリング |
+| `test` | テストの追加・修正 |
+| `chore` | ビルドプロセス・補助ツールの変更 |
+| `ci` | CI 設定ファイルの変更 |
+| `perf` | パフォーマンス改善 |
+| `revert` | コミットの取り消し |
+
+**scope（このプロジェクト固有）:**
+`scoring` / `ui` / `data` / `config` / `deps` / `ci`
+
+**description のルール:**
+- 英語・命令形（"add" 〇、"added" / "adds" ×）
+- 小文字始まり
+- 末尾ピリオドなし
+- 72 文字以内
+
+### ステップ 3: コミットを実行する
+
+```bash
+git commit -m "<生成したメッセージ>"
+```
+
+複数の独立した変更がある場合は複数コミットに分割することを推奨。
+
+## 生成例
+
+```
+feat(scoring): add substat roll count calculation
+fix(ui): correct artifact score color for S rank threshold
+docs: add GOOD format specification reference
+test(scoring): add edge cases for zero-value substats
+chore(deps): update next.js from 16.0.0 to 16.1.0
+refactor(scoring): extract stat weight lookup to separate function
+```
+
+## 注意事項
+
+- コミット前に品質ゲートを必ず通過させること: `cd webapp && npm run lint -- --fix && npm run typecheck && npm test`
+- `git add -A` / `git add .` は避け、関連ファイルのみをステージングすること
+- `.env` 等の秘密情報ファイルをコミットしないこと

--- a/.claude/skills/nextjs-best-practices/SKILL.md
+++ b/.claude/skills/nextjs-best-practices/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: nextjs-best-practices
+description: 'Next.js App Router のベストプラクティスを適用するスキル。Server/Client Components の分離・データフェッチ・ルーティングの最適化を行う。'
+---
+
+# Next.js Best Practices スキル
+
+Next.js 16 App Router のベストプラクティスをコードベースに適用します。
+
+## 参照ドキュメント
+
+- `CLAUDE.md` — プロジェクト設定（basePath, output: "export"）
+- `docs/dev/component_design.md` — コンポーネント設計
+
+## Server Components vs Client Components
+
+### Server Components（デフォルト）
+ファイルトップに `"use client"` がないコンポーネント。
+
+**推奨用途:**
+- データフェッチ
+- 静的なレイアウト・UI
+- ファイルシステムへのアクセス
+- 機密情報（API キー等）を扱う処理
+
+**このプロジェクトでの使用例:**
+```tsx
+// app/page.tsx - Server Component
+import { loadArtifacts } from '@/lib/artifacts'
+
+export default async function HomePage() {
+  const artifacts = await loadArtifacts()
+  return <ArtifactList artifacts={artifacts} />
+}
+```
+
+### Client Components（`"use client"` 必要）
+
+**推奨用途:**
+- イベントハンドラ（onClick, onChange 等）
+- `useState` / `useEffect` の使用
+- ブラウザ API へのアクセス
+- インタラクティブな UI
+
+```tsx
+"use client"
+// フィルタコンポーネント等のインタラクティブ要素のみ
+```
+
+## Static Export 対応
+
+このプロジェクトは `output: "export"` を使用。以下の制約に注意:
+
+- `next/headers` は使用不可
+- Route Handlers は限定的にしか使用できない
+- `getServerSideProps` は使用不可（静的のみ）
+- 画像パスは `process.env.BASE_PATH` を先頭に付与
+
+```tsx
+const basePath = process.env.BASE_PATH || ''
+<img src={`${basePath}/images/artifact.png`} />
+// または next/image の loader を使用
+```
+
+## データフェッチのベストプラクティス
+
+```tsx
+// ✅ Good: Server Component でのデータフェッチ
+async function ArtifactPage() {
+  const data = await fetchData() // サーバー側で実行
+  return <ArtifactDisplay data={data} />
+}
+
+// ❌ Bad: Client Component での不必要なデータフェッチ
+"use client"
+function ArtifactPage() {
+  const [data, setData] = useState(null)
+  useEffect(() => {
+    fetchData().then(setData) // 避けるべきパターン
+  }, [])
+}
+```
+
+## ルーティング構成
+
+App Router のファイル規約:
+- `app/page.tsx` — ページコンポーネント
+- `app/layout.tsx` — レイアウト
+- `app/error.tsx` — エラー境界
+- `app/loading.tsx` — ローディング UI
+
+## チェックリスト
+
+コードレビュー時に確認:
+
+- [ ] `"use client"` は最小限か（必要な場合のみ）
+- [ ] データフェッチは Server Component で行われているか
+- [ ] `BASE_PATH` を画像パスに付与しているか
+- [ ] Static Export と互換性のある API を使用しているか
+- [ ] `next/image` を使用しているか（`<img>` タグより優先）
+- [ ] `next/link` を使用しているか（`<a>` タグより優先）
+- [ ] メタデータは `metadata` オブジェクトまたは `generateMetadata` で定義しているか

--- a/.claude/skills/tdd-workflow/SKILL.md
+++ b/.claude/skills/tdd-workflow/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: tdd-workflow
+description: 'RED-GREEN-REFACTOR サイクルによる TDD ワークフロースキル。新ロジック追加時に /tdd-workflow を実行してテスト先行開発を行う。'
+---
+
+# TDD ワークフロースキル
+
+RED → GREEN → REFACTOR の TDD サイクルで開発を進めます。
+
+**CLAUDE.md の方針:** `TDD 必須 — 新ロジック追加時は先にテストを書く`
+
+## テスト配置規則
+
+```
+webapp/src/lib/__tests__/<対象ファイル名>.test.ts
+```
+
+## RED フェーズ: 失敗するテストを書く
+
+### ステップ 1: 要件をテストで表現する
+
+```typescript
+// webapp/src/lib/__tests__/newFeature.test.ts
+import { describe, it, expect } from 'vitest'
+import { newFunction } from '../newFeature'
+
+describe('newFunction', () => {
+  it('期待する動作を説明する', () => {
+    // Arrange
+    const input = { /* テスト入力 */ }
+    const expected = { /* 期待する出力 */ }
+
+    // Act
+    const result = newFunction(input)
+
+    // Assert
+    expect(result).toEqual(expected)
+  })
+
+  it('エッジケース: 空入力の処理', () => {
+    expect(newFunction({})).toEqual(/* 期待値 */)
+  })
+})
+```
+
+### ステップ 2: テストを実行して RED を確認する
+
+```bash
+cd webapp && npm test -- --run <test-file-name>
+```
+
+テストが失敗することを確認（まだ実装がないため）。
+
+## GREEN フェーズ: テストを通す最小実装
+
+### ステップ 3: 最小限の実装を書く
+
+```typescript
+// webapp/src/lib/newFeature.ts
+export function newFunction(input: InputType): OutputType {
+  // テストを通す最小限の実装
+}
+```
+
+### ステップ 4: テストをパスさせる
+
+```bash
+cd webapp && npm test -- --run <test-file-name>
+```
+
+全テストが GREEN になることを確認。
+
+## REFACTOR フェーズ: コードを改善する
+
+### ステップ 5: 品質を高める
+
+リファクタリング時の注意:
+- テストは変更しない
+- 動作を変えずにコードを改善する
+- 重複を排除する
+- 命名を明確にする
+
+### ステップ 6: 全テストが通ることを確認
+
+```bash
+cd webapp && npm test
+```
+
+## このプロジェクトのテストパターン
+
+### スコア計算テスト
+
+```typescript
+// スコア計算関数のテストパターン
+import { calculateScore } from '../scoring'
+import type { Artifact } from '../types'
+
+describe('calculateScore', () => {
+  const mockArtifact: Artifact = {
+    // テスト用聖遺物データ
+  }
+
+  it('会心率サブステのスコアを正しく計算する', () => {
+    const result = calculateScore(mockArtifact, weights)
+    expect(result).toBeCloseTo(expected, 2)
+  })
+})
+```
+
+## 品質ゲート（全フェーズ共通）
+
+```bash
+cd webapp && npm run lint -- --fix && npm run typecheck && npm test
+```
+
+## TDD の利点
+
+- バグを早期発見できる
+- リファクタリングへの自信が増す
+- 設計が自然に改善される
+- ドキュメントとしての役割を果たす

--- a/.claude/skills/typescript-expert/SKILL.md
+++ b/.claude/skills/typescript-expert/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: typescript-expert
+description: 'TypeScript の型レベルプログラミング・パフォーマンス最適化・型安全性向上を行うスキル。TypeScript に関する問題や改善依頼時に使用する。'
+---
+
+# TypeScript Expert スキル
+
+TypeScript 5 の高度な型システムを活用してコードの型安全性と品質を向上させます。
+
+## 参照設定
+
+- `webapp/tsconfig.json` — TypeScript 設定
+- `webapp/src/lib/` — 型定義・ロジック
+
+## 型安全性の原則
+
+### `any` の禁止
+
+```typescript
+// ❌ Bad
+function process(data: any) { ... }
+
+// ✅ Good
+function process(data: ArtifactData) { ... }
+
+// ✅ Unknown を使用（型チェック強制）
+function processUnknown(data: unknown) {
+  if (isArtifactData(data)) { ... }
+}
+```
+
+### 厳格な設定
+
+```json
+// tsconfig.json の推奨設定
+{
+  "compilerOptions": {
+    "strict": true,           // 全厳格オプションを有効化
+    "noUncheckedIndexedAccess": true,  // 配列アクセスを安全に
+    "exactOptionalPropertyTypes": true  // optional の厳格化
+  }
+}
+```
+
+## 型定義パターン
+
+### ユニオン型による状態表現
+
+```typescript
+// ✅ 判別可能なユニオン型
+type ArtifactRank = 'SS' | 'S' | 'A' | 'B' | 'C'
+
+type ScoreResult =
+  | { status: 'success'; score: number; rank: ArtifactRank }
+  | { status: 'error'; message: string }
+```
+
+### ジェネリクスの活用
+
+```typescript
+// ✅ 型安全なフィルタ関数
+function filterArtifacts<T extends Artifact>(
+  artifacts: T[],
+  predicate: (artifact: T) => boolean
+): T[] {
+  return artifacts.filter(predicate)
+}
+```
+
+### Mapped Types と Utility Types
+
+```typescript
+// ✅ 既存型からの派生
+type ArtifactSummary = Pick<Artifact, 'id' | 'setKey' | 'slotKey'>
+type PartialArtifact = Partial<Artifact>
+type ReadonlyArtifact = Readonly<Artifact>
+
+// ✅ カスタム Mapped Type
+type StatWeights = {
+  [K in SubstatKey]: number
+}
+```
+
+## 型推論の最大活用
+
+```typescript
+// ✅ as const でリテラル型を維持
+const SLOT_KEYS = ['flower', 'plume', 'sands', 'goblet', 'circlet'] as const
+type SlotKey = typeof SLOT_KEYS[number]  // 'flower' | 'plume' | ...
+
+// ✅ satisfies で型チェックしながら推論を維持
+const weights = {
+  critRate: 2.0,
+  critDMG: 1.0,
+} satisfies Record<string, number>
+```
+
+## 型ガードの実装
+
+```typescript
+// ✅ カスタム型ガード
+function isArtifact(value: unknown): value is Artifact {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'setKey' in value &&
+    'slotKey' in value
+  )
+}
+```
+
+## チェックリスト
+
+- [ ] `any` を使用していないか
+- [ ] 全ての関数に戻り値の型注釈があるか（推論できない場合）
+- [ ] ユニオン型に型ガードが適切に実装されているか
+- [ ] `as` によるキャストを最小限にしているか
+- [ ] `noUncheckedIndexedAccess` に対応しているか（配列アクセスの安全性）
+- [ ] 型コメントは英語で記述されているか
+
+## 型エラーのデバッグ
+
+```bash
+cd webapp && npm run typecheck
+```
+
+型エラーが出た場合:
+1. エラーメッセージを読む
+2. 型定義を確認する
+3. `any` で誤魔化さず、正しい型を定義する


### PR DESCRIPTION
closes #34

## Summary

- `frontend-developer` エージェントを追加
- `commit-smart` / `nextjs-best-practices` / `tdd-workflow` / `typescript-expert` スキルを追加
- `conventional-commits` / `tdd-gate` / `run-tests-after-changes` フックを settings.json に追加
- npm コマンドと git 操作の自動描可権限を追加

Generated with [Claude Code](https://claude.ai/code)