### PR TITLE
fix: 聖遺物アイコン右横の説明を変更（部位・メインステを別行に分離、レベル表示を削除）

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -523,15 +523,9 @@ body {
   margin-top: 0.1rem;
 }
 
-.main-stat-inline {
+.main-stat-line {
   color: var(--gold-light);
   font-size: 0.7rem;
-  white-space: nowrap;
-}
-
-.level {
-  font-size: 0.75rem;
-  color: #6ea8ff;
   margin-top: 0.1rem;
 }
 

--- a/webapp/src/components/ArtifactCard.tsx
+++ b/webapp/src/components/ArtifactCard.tsx
@@ -144,16 +144,13 @@ export default function ArtifactCard({ rank, entry, scoreType, reconRate, onFilt
           />
         </div>
 
-        {/* セット名・部位・メインステータス・レベル */}
+        {/* セット名・部位・メインステータス */}
         <div className="artifact-info">
           <p className="set-name">{setName}</p>
-          <p className="slot-name">
-            {slotName}
-            {mainStatValue && (
-              <span className="main-stat-inline"> · {mainStatName} {mainStatValue}</span>
-            )}
-          </p>
-          <p className="level">+{level}</p>
+          <p className="slot-name">{slotName}</p>
+          {mainStatValue && (
+            <p className="main-stat-line">{mainStatName} {mainStatValue}</p>
+          )}
         </div>
 
         {/* キャラアイコン（クリックで装備セットフィルタメニュー） */}


### PR DESCRIPTION
Closes #61

Generated with [Claude Code](https://claude.ai/code)