### PR TITLE
fix: 言語切替ボタンをサイドバー下部に固定

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -41,12 +41,15 @@ body {
   top: 0;
   height: 100vh;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar-list {
   list-style: none;
   margin: 0;
   padding: 0;
+  flex: 1;
 }
 
 .sidebar-link {


### PR DESCRIPTION
fixes #64

.sidebar に display:flex / flex-direction:column を追加し、.sidebar-list に flex:1 を追加して言語切替ボタンをサイドバー最下部に固定します。

Generated with [Claude Code](https://claude.ai/code)