### PR TITLE
test: Playwright ビジュアルリグレッションテスト環境の構築

### DIFF
--- a/webapp/e2e/controls-bar.spec.ts
+++ b/webapp/e2e/controls-bar.spec.ts
@@ -1,0 +1,39 @@
+import path from 'path'
+import { test, expect } from '@playwright/test'
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'test-good.json')
+
+test.describe('コントロールバー レイアウトテスト', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+
+    // ファイルアップロードでコントロールバーを表示する
+    const fileInput = page.locator('input[type="file"]')
+    await fileInput.setInputFiles(FIXTURE_PATH)
+
+    // コントロールバーが表示されるまで待機
+    await page.waitForSelector('.controls-bar', { state: 'visible' })
+  })
+
+  test('コントロールバーが画面外にはみ出していないこと', async ({ page }) => {
+    const overflow = await page.evaluate(() => {
+      const bar = document.querySelector('.controls-bar')
+      if (!bar) return { scrollWidth: 0, clientWidth: 0, overflows: true }
+      return {
+        scrollWidth: bar.scrollWidth,
+        clientWidth: bar.clientWidth,
+        overflows: bar.scrollWidth > bar.clientWidth,
+      }
+    })
+
+    expect(
+      overflow.overflows,
+      `コントロールバーがはみ出しています: scrollWidth(${overflow.scrollWidth}) > clientWidth(${overflow.clientWidth})`,
+    ).toBe(false)
+  })
+
+  test('コントロールバーのスクリーンショット', async ({ page }, testInfo) => {
+    const controlsBar = page.locator('.controls-bar')
+    await expect(controlsBar).toHaveScreenshot(`controls-bar-${testInfo.project.name}.png`)
+  })
+})

--- a/webapp/e2e/fixtures/test-good.json
+++ b/webapp/e2e/fixtures/test-good.json
@@ -1,0 +1,67 @@
+{
+  "format": "GOOD",
+  "version": 3,
+  "source": "test",
+  "characters": [],
+  "artifacts": [
+    {
+      "setKey": "GladiatorsFinale",
+      "slotKey": "flower",
+      "level": 20,
+      "rarity": 5,
+      "mainStatKey": "hp",
+      "location": "",
+      "lock": false,
+      "substats": [
+        { "key": "critRate_", "value": 9.3, "initialValue": 3.1 },
+        { "key": "critDMG_", "value": 19.4, "initialValue": 9.7 },
+        { "key": "atk", "value": 33.0, "initialValue": 18.0 },
+        { "key": "atk_", "value": 5.8, "initialValue": 5.8 }
+      ],
+      "totalRolls": 8,
+      "astralMark": false,
+      "elixerCrafted": false,
+      "unactivatedSubstats": []
+    },
+    {
+      "setKey": "GladiatorsFinale",
+      "slotKey": "plume",
+      "level": 20,
+      "rarity": 5,
+      "mainStatKey": "atk",
+      "location": "",
+      "lock": false,
+      "substats": [
+        { "key": "critRate_", "value": 6.2, "initialValue": 3.1 },
+        { "key": "critDMG_", "value": 29.1, "initialValue": 9.7 },
+        { "key": "hp_", "value": 5.3, "initialValue": 5.3 },
+        { "key": "def", "value": 21.0, "initialValue": 21.0 }
+      ],
+      "totalRolls": 8,
+      "astralMark": false,
+      "elixerCrafted": false,
+      "unactivatedSubstats": []
+    },
+    {
+      "setKey": "GladiatorsFinale",
+      "slotKey": "sands",
+      "level": 20,
+      "rarity": 5,
+      "mainStatKey": "atk_",
+      "location": "",
+      "lock": false,
+      "substats": [
+        { "key": "critRate_", "value": 9.3, "initialValue": 3.1 },
+        { "key": "critDMG_", "value": 9.7, "initialValue": 9.7 },
+        { "key": "atk", "value": 53.0, "initialValue": 18.0 },
+        { "key": "eleMas", "value": 21.0, "initialValue": 21.0 }
+      ],
+      "totalRolls": 8,
+      "astralMark": false,
+      "elixerCrafted": false,
+      "unactivatedSubstats": []
+    }
+  ],
+  "weapons": [],
+  "materials": {}
+}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test",
+    "test:e2e:update": "playwright test --update-snapshots"
   },
   "dependencies": {
     "next": "16.1.6",
@@ -20,6 +22,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@playwright/test": "^1.50.0",
     "@vitest/ui": "^4.0.18",
     "tailwindcss": "^4",
     "typescript": "^5",

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000/mogumogu-paimon',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: '900px',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 900, height: 800 },
+      },
+    },
+    {
+      name: '1280px',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 800 },
+      },
+    },
+    {
+      name: '1920px',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1920, height: 1080 },
+      },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000/mogumogu-paimon',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+})


### PR DESCRIPTION
closes #65

## 変更内容

- `@playwright/test` を devDependencies に追加
- `playwright.config.ts` を作成（3ビューポート: 900px/1280px/1920px）
- `e2e/controls-bar.spec.ts` を作成（オーバーフロー検証 + スクリーンショット比較）
- `test:e2e` スクリプトを package.json に追加

Generated with [Claude Code](https://claude.ai/code)