### PR TITLE
fix: remove excess whitespace from controls-bar by eliminating full-width ctrl-end row

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -271,7 +271,6 @@ body {
 }
 
 .ctrl-end {
-  grid-column: 1 / -1;
   display: flex;
   flex-direction: row;
   justify-content: flex-end;

--- a/webapp/src/app/page.tsx
+++ b/webapp/src/app/page.tsx
@@ -449,18 +449,17 @@ export default function HomePage() {
               </label>
             </div>
 
-            {/* 件数 + フィルタクリア + 再アップロード */}
-            <div className="ctrl-group ctrl-end">
-<div className="ctrl-buttons">
+            {/* フィルタクリア（フィルタ設定時のみ表示） */}
+            {(filterSets.length > 0 || filterSlot || filterMainStat || filterSubStats.length > 0 || filterInitialOp) && (
+              <div className="ctrl-group ctrl-end">
                 <button
                   className="ctrl-btn ctrl-clear"
-                  style={{ visibility: (filterSets.length > 0 || filterSlot || filterMainStat || filterSubStats.length > 0 || filterInitialOp) ? 'visible' : 'hidden' }}
                   onClick={() => { setFilterSets([]); setFilterSlot(''); setFilterMainStat(''); setFilterSubStats([]); setFilterInitialOp('') }}
                 >
                   {t.controls.filterClear}
                 </button>
               </div>
-            </div>
+            )}
           </div>
 
           {/* ── カードグリッド ── */}


### PR DESCRIPTION
- Remove grid-column: 1/-1 from .ctrl-end so it no longer forces a dedicated full-width row
- Conditionally render the filter-clear button only when filters are active, eliminating the invisible placeholder row

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>