### PR TITLE
feat: フィルタをクリアボタンを1920pxで1列表示

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -254,7 +254,7 @@ body {
 /* ── コントロールバー ───────────────────── */
 .controls-bar {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
   gap: 1rem;
   align-items: end;
   margin-bottom: 1.25rem;
@@ -439,9 +439,14 @@ body {
   border-color: var(--gold);
 }
 
-.ctrl-clear:hover {
+.ctrl-clear:hover:not(:disabled) {
   color: var(--danger);
   border-color: var(--danger);
+}
+
+.ctrl-clear:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 

--- a/webapp/src/app/page.tsx
+++ b/webapp/src/app/page.tsx
@@ -9,6 +9,7 @@ import { calculateAllScores, calculateScores, estimateRollCounts } from '@/lib/s
 import { calculateReconstructionRate } from '@/lib/reconstruction'
 import { ARTIFACT_SET_NAMES, MAIN_STAT_NAMES, SLOT_NAMES, STAT_NAMES, groupSetOptions } from '@/lib/constants'
 import { useTranslation } from '@/lib/i18n'
+import { hasActiveFilter } from '@/lib/filterUtils'
 
 const basePath = process.env.BASE_PATH ?? ''
 
@@ -449,17 +450,16 @@ export default function HomePage() {
               </label>
             </div>
 
-            {/* フィルタクリア（フィルタ設定時のみ表示） */}
-            {(filterSets.length > 0 || filterSlot || filterMainStat || filterSubStats.length > 0 || filterInitialOp) && (
-              <div className="ctrl-group ctrl-end">
-                <button
-                  className="ctrl-btn ctrl-clear"
-                  onClick={() => { setFilterSets([]); setFilterSlot(''); setFilterMainStat(''); setFilterSubStats([]); setFilterInitialOp('') }}
-                >
-                  {t.controls.filterClear}
-                </button>
-              </div>
-            )}
+            {/* フィルタクリア（常に表示） */}
+            <div className="ctrl-group ctrl-end">
+              <button
+                className="ctrl-btn ctrl-clear"
+                disabled={!hasActiveFilter(filterSets, filterSlot, filterMainStat, filterSubStats, filterInitialOp)}
+                onClick={() => { setFilterSets([]); setFilterSlot(''); setFilterMainStat(''); setFilterSubStats([]); setFilterInitialOp('') }}
+              >
+                {t.controls.filterClear}
+              </button>
+            </div>
           </div>
 
           {/* ── カードグリッド ── */}

--- a/webapp/src/lib/__tests__/filterUtils.test.ts
+++ b/webapp/src/lib/__tests__/filterUtils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { hasActiveFilter } from '@/lib/filterUtils'
+
+describe('hasActiveFilter', () => {
+  it('フィルタがすべて未設定のとき false を返す', () => {
+    expect(hasActiveFilter([], '', '', [], '')).toBe(false)
+  })
+
+  it('セットフィルタが設定されているとき true を返す', () => {
+    expect(hasActiveFilter(['GladiatorsFinale'], '', '', [], '')).toBe(true)
+  })
+
+  it('部位フィルタが設定されているとき true を返す', () => {
+    expect(hasActiveFilter([], 'flower', '', [], '')).toBe(true)
+  })
+
+  it('メインステフィルタが設定されているとき true を返す', () => {
+    expect(hasActiveFilter([], '', 'critRate_', [], '')).toBe(true)
+  })
+
+  it('サブステフィルタが設定されているとき true を返す', () => {
+    expect(hasActiveFilter([], '', '', ['critDMG_'], '')).toBe(true)
+  })
+
+  it('初期OPフィルタが 3 のとき true を返す', () => {
+    expect(hasActiveFilter([], '', '', [], '3')).toBe(true)
+  })
+
+  it('初期OPフィルタが 4 のとき true を返す', () => {
+    expect(hasActiveFilter([], '', '', [], '4')).toBe(true)
+  })
+
+  it('複数のフィルタが設定されているとき true を返す', () => {
+    expect(hasActiveFilter(['GladiatorsFinale'], 'sands', 'atk_', ['critRate_'], '4')).toBe(true)
+  })
+})

--- a/webapp/src/lib/filterUtils.ts
+++ b/webapp/src/lib/filterUtils.ts
@@ -1,0 +1,18 @@
+import type { ArtifactSlotKey, StatKey } from '@/lib/types'
+
+/** いずれかのフィルタが有効かどうかを返す */
+export function hasActiveFilter(
+  filterSets: string[],
+  filterSlot: ArtifactSlotKey | '',
+  filterMainStat: string,
+  filterSubStats: StatKey[],
+  filterInitialOp: '' | '3' | '4',
+): boolean {
+  return (
+    filterSets.length > 0 ||
+    filterSlot !== '' ||
+    filterMainStat !== '' ||
+    filterSubStats.length > 0 ||
+    filterInitialOp !== ''
+  )
+}

--- a/webapp/vitest.config.ts
+++ b/webapp/vitest.config.ts
@@ -4,6 +4,7 @@ import path from 'path'
 export default defineConfig({
   test: {
     environment: 'node',
+    exclude: ['**/node_modules/**', '**/e2e/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #75

## 変更内容

- 「フィルタをクリア」ボタンを常に表示（フィルタ未設定時は disabled に）
- 1920px 幅でコントロールバーが1列に収まるようCSS調整
- hasActiveFilter 関数の抽出とユニットテスト 8件追加

Generated with [Claude Code](https://claude.ai/code)