### PR TITLE
refactor: app/page.tsx の分割（カスタムフック化 + コンポーネント抽出）

### DIFF
--- a/webapp/src/app/page.tsx
+++ b/webapp/src/app/page.tsx
@@ -1,20 +1,31 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
-import FileUpload from '@/components/FileUpload'
+import { useMemo, useState } from 'react'
 import ArtifactCard from '@/components/ArtifactCard'
-import type { ArtifactSlotKey, GoodFile, RankedArtifact, ReconstructionType, ScoreTypeName, StatKey } from '@/lib/types'
+import HeroSection from '@/components/HeroSection'
+import ControlsBar from '@/components/ControlsBar'
+import type { GoodFile, RankedArtifact, ReconstructionType, ScoreTypeName, StatKey } from '@/lib/types'
 import { calculateAllScores, calculateScores, estimateRollCounts } from '@/lib/scoring'
 import { calculateReconstructionRate } from '@/lib/reconstruction'
-import { ARTIFACT_SET_NAMES, MAIN_STAT_NAMES, SLOT_NAMES, STAT_NAMES, groupSetOptions } from '@/lib/constants'
+import { groupSetOptions } from '@/lib/constants'
 import { useTranslation } from '@/lib/i18n'
-import { hasActiveFilter } from '@/lib/filterUtils'
-
-const basePath = process.env.BASE_PATH ?? ''
+import { useArtifactFilters } from '@/hooks/useArtifactFilters'
 
 const SCORE_TYPE_OPTIONS: ScoreTypeName[] = [
   'CV', '攻撃型', 'HP型', '防御型', '熟知型', 'チャージ型', '最良型',
+]
+
+const ALL_SUBSTAT_KEYS: StatKey[] = [
+  'critRate_', 'critDMG_', 'atk_', 'hp_', 'def_',
+  'eleMas', 'enerRech_', 'atk', 'hp', 'def',
+]
+
+const MAIN_STAT_ORDER: string[] = [
+  'critRate_', 'critDMG_', 'atk_', 'hp_', 'def_',
+  'eleMas', 'enerRech_', 'heal_',
+  'anemo_dmg_', 'geo_dmg_', 'electro_dmg_', 'dendro_dmg_',
+  'hydro_dmg_', 'pyro_dmg_', 'cryo_dmg_',
+  'atk', 'hp', 'def',
 ]
 
 /** GOODファイルを読み込んで★5聖遺物をランク付けする */
@@ -31,99 +42,35 @@ function buildRankedList(data: GoodFile): RankedArtifact[] {
 
 export default function HomePage() {
   const { t } = useTranslation()
+  const filters = useArtifactFilters()
   const [allRanked, setAllRanked] = useState<RankedArtifact[] | null>(null)
   const [scoreType, setScoreType] = useState<ScoreTypeName>('攻撃型')
-  const [filterSets, setFilterSets] = useState<string[]>([])
-  const [filterSlot, setFilterSlot] = useState<ArtifactSlotKey | ''>('')
-  const [filterMainStat, setFilterMainStat] = useState('')
-  const [filterSubStats, setFilterSubStats] = useState<StatKey[]>([])
-  const [filterInitialOp, setFilterInitialOp] = useState<'' | '3' | '4'>('')
   const [subStatSort, setSubStatSort] = useState<StatKey | ''>('')
-  const [subStatOpen, setSubStatOpen] = useState(false)
-  const subStatBtnRef = useRef<HTMLButtonElement>(null)
-  const subStatPanelRef = useRef<HTMLDivElement>(null)
-  const [setFilterOpen, setSetFilterOpen] = useState(false)
-  const setFilterBtnRef = useRef<HTMLButtonElement>(null)
-  const setFilterPanelRef = useRef<HTMLDivElement>(null)
   const [reconType, setReconType] = useState<ReconstructionType>('normal')
   const [reconSort, setReconSort] = useState(false)
 
-  // ドロップダウンの外側クリック・Escキーで閉じる共通処理
-  useEffect(() => {
-    if (!subStatOpen && !setFilterOpen) return
-    function handleClick(e: MouseEvent) {
-      const target = e.target as Node
-      if (
-        subStatOpen &&
-        subStatBtnRef.current && !subStatBtnRef.current.contains(target) &&
-        subStatPanelRef.current && !subStatPanelRef.current.contains(target)
-      ) {
-        setSubStatOpen(false)
-      }
-      if (
-        setFilterOpen &&
-        setFilterBtnRef.current && !setFilterBtnRef.current.contains(target) &&
-        setFilterPanelRef.current && !setFilterPanelRef.current.contains(target)
-      ) {
-        setSetFilterOpen(false)
-      }
-    }
-    function handleKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        setSubStatOpen(false)
-        setSetFilterOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClick)
-    document.addEventListener('keydown', handleKey)
-    return () => {
-      document.removeEventListener('mousedown', handleClick)
-      document.removeEventListener('keydown', handleKey)
-    }
-  }, [subStatOpen, setFilterOpen])
-
   function handleLoad(data: GoodFile) {
     setAllRanked(buildRankedList(data))
-    setFilterSets([])
-    setFilterSlot('')
-    setFilterMainStat('')
-    setFilterSubStats([])
-    setFilterInitialOp('')
-    setSubStatSort('')
+    filters.resetFilters()
   }
 
-  // アップロードデータに含まれる setKey をグループ化して列挙
   const setOptionGroups = useMemo(() => {
     if (!allRanked) return []
     const keys = [...new Set(allRanked.map((e) => e.artifact.setKey))]
     return groupSetOptions(keys)
   }, [allRanked])
 
-  // アップロードデータに存在するメインステキーの一覧（固定順序）
-  const MAIN_STAT_ORDER: string[] = [
-    'critRate_', 'critDMG_', 'atk_', 'hp_', 'def_',
-    'eleMas', 'enerRech_', 'heal_',
-    'anemo_dmg_', 'geo_dmg_', 'electro_dmg_', 'dendro_dmg_',
-    'hydro_dmg_', 'pyro_dmg_', 'cryo_dmg_',
-    'atk', 'hp', 'def',
-  ]
   const mainStatOptions = useMemo(() => {
     if (!allRanked) return []
     const present = new Set(allRanked.map((e) => e.artifact.mainStatKey))
     return MAIN_STAT_ORDER.filter((k) => present.has(k))
   }, [allRanked])
 
-  // メインステフィルタが選択されている場合、同じキーをサブステ選択肢から除外
-  const ALL_SUBSTAT_KEYS: StatKey[] = [
-    'critRate_', 'critDMG_', 'atk_', 'hp_', 'def_',
-    'eleMas', 'enerRech_', 'atk', 'hp', 'def',
-  ]
   const availableSubStatKeys = useMemo((): StatKey[] => {
-    if (!filterMainStat) return ALL_SUBSTAT_KEYS
-    return ALL_SUBSTAT_KEYS.filter((k) => k !== filterMainStat)
-  }, [filterMainStat])
+    if (!filters.filterMainStat) return ALL_SUBSTAT_KEYS
+    return ALL_SUBSTAT_KEYS.filter((k) => k !== filters.filterMainStat)
+  }, [filters.filterMainStat])
 
-  // キャラ名 → 装備セットキー配列のマップ
   const equippedSetsMap = useMemo(() => {
     if (!allRanked) return new Map<string, string[]>()
     const map = new Map<string, string[]>()
@@ -137,7 +84,6 @@ export default function HomePage() {
     return map
   }, [allRanked])
 
-  // 再構築成功率マップ（entry index → rate）
   const reconRates = useMemo(() => {
     if (!allRanked) return new Map<number, number>()
     const map = new Map<number, number>()
@@ -149,26 +95,24 @@ export default function HomePage() {
     return map
   }, [allRanked, scoreType, reconType])
 
-  // フィルタ・ソート済みリスト（再構築成功率付き）
   const displayed = useMemo(() => {
     if (!allRanked) return []
     return allRanked
       .map((e, i) => ({ entry: e, reconRate: reconRates.get(i) ?? null }))
-      .filter(({ entry: e }) => filterSets.length === 0 || filterSets.includes(e.artifact.setKey))
-      .filter(({ entry: e }) => !filterSlot || e.artifact.slotKey === filterSlot)
-      .filter(({ entry: e }) => !filterMainStat || e.artifact.mainStatKey === filterMainStat)
+      .filter(({ entry: e }) => filters.filterSets.length === 0 || filters.filterSets.includes(e.artifact.setKey))
+      .filter(({ entry: e }) => !filters.filterSlot || e.artifact.slotKey === filters.filterSlot)
+      .filter(({ entry: e }) => !filters.filterMainStat || e.artifact.mainStatKey === filters.filterMainStat)
       .filter(({ entry: e }) =>
-        filterSubStats.length === 0 ||
-        filterSubStats.every((k) => e.artifact.substats.some((s) => s.key === k)),
+        filters.filterSubStats.length === 0 ||
+        filters.filterSubStats.every((k) => e.artifact.substats.some((s) => s.key === k)),
       )
       .filter(({ entry: e }) => {
-        if (!filterInitialOp) return true
+        if (!filters.filterInitialOp) return true
         const initialOp = e.artifact.totalRolls - Math.floor(e.artifact.level / 4)
-        return initialOp === Number(filterInitialOp)
+        return initialOp === Number(filters.filterInitialOp)
       })
       .sort((a, b) => {
         if (reconSort) {
-          // 再構築成功率ソートON: 成功率の高い順（nullは末尾）
           const ra = a.reconRate ?? -1
           const rb = b.reconRate ?? -1
           if (ra !== rb) return rb - ra
@@ -180,289 +124,35 @@ export default function HomePage() {
         }
         return b.entry.allScores[scoreType] - a.entry.allScores[scoreType]
       })
-  }, [allRanked, filterSets, filterSlot, filterMainStat, filterSubStats, filterInitialOp, subStatSort, scoreType, reconRates, reconSort])
+  }, [allRanked, filters.filterSets, filters.filterSlot, filters.filterMainStat, filters.filterSubStats, filters.filterInitialOp, subStatSort, scoreType, reconRates, reconSort])
 
   const allMainStatNames: Record<string, string> = { ...t.stats, ...t.mainStatExtra }
 
-  const RECON_OPTIONS: { value: ReconstructionType; label: string }[] = [
-    { value: 'normal', label: t.reconTypes.normal },
-    { value: 'advanced', label: t.reconTypes.advanced },
-    { value: 'absolute', label: t.reconTypes.absolute },
-  ]
-
-  const SLOT_OPTIONS: { value: ArtifactSlotKey | ''; label: string }[] = [
-    { value: '', label: t.controls.allSlots },
-    { value: 'flower', label: t.slots.flower },
-    { value: 'plume', label: t.slots.plume },
-    { value: 'sands', label: t.slots.sands },
-    { value: 'goblet', label: t.slots.goblet },
-    { value: 'circlet', label: t.slots.circlet },
-  ]
-
   return (
     <main className="main-container">
-      {/* ── ヘッダー ── */}
       <h1 className="page-title">{t.siteTitle}</h1>
 
-      {/* ── 空状態: ヒーロー画像 + アップロード ── */}
       {allRanked === null ? (
-        <div className="hero-section">
-          <FileUpload onLoad={handleLoad} />
-          {/* スコア計算式の説明 */}
-          <div className="score-formulas">
-            <p className="score-formulas-title">{t.pages.aboutScore.formulaList.heading}</p>
-            <ul className="score-formulas-list">
-              {SCORE_TYPE_OPTIONS.map((type) => (
-                <li key={type} className="score-formulas-item">
-                  <span className="score-formulas-label">{t.scoreFormulas[type].label}</span>
-                  <span className="score-formulas-eq">=</span>
-                  <span className="score-formulas-formula">{t.scoreFormulas[type].formula}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
+        <HeroSection onLoad={handleLoad} t={t} scoreTypeOptions={SCORE_TYPE_OPTIONS} />
       ) : (
         <>
-          {/* ── コントロールバー ── */}
-          <div className="controls-bar">
-            {/* スコアタイプ */}
-            <div className="ctrl-group">
-              <label className="ctrl-label">{t.controls.scoreType}</label>
-              <select
-                className="ctrl-select"
-                value={scoreType}
-                onChange={(e) => setScoreType(e.target.value as ScoreTypeName)}
-              >
-                {SCORE_TYPE_OPTIONS.map((type) => (
-                  <option key={type} value={type}>{t.scoreFormulas[type].label}</option>
-                ))}
-              </select>
-            </div>
+          <ControlsBar
+            filters={filters}
+            scoreType={scoreType}
+            setScoreType={setScoreType}
+            subStatSort={subStatSort}
+            setSubStatSort={setSubStatSort}
+            reconType={reconType}
+            setReconType={setReconType}
+            reconSort={reconSort}
+            setReconSort={setReconSort}
+            mainStatOptions={mainStatOptions}
+            setOptionGroups={setOptionGroups}
+            availableSubStatKeys={availableSubStatKeys}
+            t={t}
+            allMainStatNames={allMainStatNames}
+          />
 
-            {/* セットフィルタ */}
-            <div className="ctrl-group">
-              <label className="ctrl-label">{t.controls.set}</label>
-              <button
-                ref={setFilterBtnRef}
-                type="button"
-                className="substat-dropdown-btn"
-                onClick={() => setSetFilterOpen((v) => !v)}
-              >
-                {filterSets.length > 0
-                  ? `${t.controls.set}(${filterSets.length})`
-                  : t.controls.set}
-              </button>
-              {setFilterOpen && createPortal(
-                <div
-                  ref={setFilterPanelRef}
-                  className="set-dropdown-panel"
-                  style={{
-                    top: (setFilterBtnRef.current?.getBoundingClientRect().bottom ?? 0) + 4,
-                    left: setFilterBtnRef.current?.getBoundingClientRect().left ?? 0,
-                  }}
-                >
-                  {setOptionGroups.map((group) => {
-                    const allSelected = group.keys.every((k) => filterSets.includes(k))
-                    const someSelected = group.keys.some((k) => filterSets.includes(k))
-                    const groupLabel = t.setGroupLabels[group.label] ?? group.label
-                    return (
-                      <div key={group.label}>
-                        <label className="set-group-header">
-                          <input
-                            type="checkbox"
-                            className="ctrl-checkbox"
-                            checked={allSelected}
-                            ref={(el) => {
-                              if (el) el.indeterminate = someSelected && !allSelected
-                            }}
-                            onChange={() => {
-                              setFilterSets((prev) => {
-                                if (allSelected) {
-                                  return prev.filter((k) => !group.keys.includes(k))
-                                }
-                                const toAdd = group.keys.filter((k) => !prev.includes(k))
-                                return [...prev, ...toAdd]
-                              })
-                            }}
-                          />
-                          {groupLabel}
-                        </label>
-                        {group.keys.map((key) => (
-                          <label key={key} className="substat-dropdown-item set-item">
-                            <input
-                              type="checkbox"
-                              className="ctrl-checkbox"
-                              checked={filterSets.includes(key)}
-                              onChange={(e) => {
-                                setFilterSets((prev) =>
-                                  e.target.checked
-                                    ? [...prev, key]
-                                    : prev.filter((k) => k !== key),
-                                )
-                              }}
-                            />
-                            {t.artifactSetNames[key] ?? ARTIFACT_SET_NAMES[key] ?? key}
-                          </label>
-                        ))}
-                      </div>
-                    )
-                  })}
-                </div>,
-                document.body,
-              )}
-            </div>
-
-            {/* 部位フィルタ */}
-            <div className="ctrl-group">
-              <label className="ctrl-label">{t.controls.slot}</label>
-              <select
-                className="ctrl-select"
-                value={filterSlot}
-                onChange={(e) => setFilterSlot(e.target.value as ArtifactSlotKey | '')}
-              >
-                {SLOT_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </select>
-            </div>
-
-            {/* メインステフィルタ */}
-            <div className="ctrl-group">
-              <label className="ctrl-label">{t.controls.mainStat}</label>
-              <select
-                className="ctrl-select"
-                value={filterMainStat}
-                onChange={(e) => {
-                  const val = e.target.value
-                  setFilterMainStat(val)
-                  setFilterSubStats((prev) => prev.filter((k) => k !== val))
-                }}
-              >
-                <option value="">{t.controls.allMainStats}</option>
-                {mainStatOptions.map((key) => (
-                  <option key={key} value={key}>
-                    {allMainStatNames[key] ?? MAIN_STAT_NAMES[key] ?? key}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {/* 初期OPフィルタ */}
-            <div className="ctrl-group">
-              <label className="ctrl-label">{t.controls.initialOp}</label>
-              <select
-                className="ctrl-select"
-                value={filterInitialOp}
-                onChange={(e) => setFilterInitialOp(e.target.value as '' | '3' | '4')}
-              >
-                <option value="">{t.controls.allOps}</option>
-                <option value="3">{t.controls.op3}</option>
-                <option value="4">{t.controls.op4}</option>
-              </select>
-            </div>
-
-            {/* サブステフィルタ */}
-            <div className="ctrl-group">
-              <label className="ctrl-label">{t.controls.substatFilter}</label>
-              <button
-                ref={subStatBtnRef}
-                type="button"
-                className="substat-dropdown-btn"
-                onClick={() => setSubStatOpen((v) => !v)}
-              >
-                {filterSubStats.length > 0
-                  ? `${t.controls.substatBtn}(${filterSubStats.length})`
-                  : t.controls.substatBtn}
-              </button>
-              {subStatOpen && createPortal(
-                <div
-                  ref={subStatPanelRef}
-                  className="substat-dropdown-panel"
-                  style={{
-                    top: (subStatBtnRef.current?.getBoundingClientRect().bottom ?? 0) + 4,
-                    left: subStatBtnRef.current?.getBoundingClientRect().left ?? 0,
-                  }}
-                >
-                  {availableSubStatKeys.map((key) => (
-                    <label key={key} className="substat-dropdown-item">
-                      <input
-                        type="checkbox"
-                        className="ctrl-checkbox"
-                        checked={filterSubStats.includes(key)}
-                        onChange={(e) => {
-                          setFilterSubStats((prev) =>
-                            e.target.checked
-                              ? [...prev, key]
-                              : prev.filter((k) => k !== key),
-                          )
-                        }}
-                      />
-                      {t.stats[key] ?? STAT_NAMES[key]}
-                    </label>
-                  ))}
-                </div>,
-                document.body,
-              )}
-            </div>
-
-            {/* サブステソート */}
-            <div className="ctrl-group">
-              <label className="ctrl-label">{t.controls.substatSort}</label>
-              <select
-                className="ctrl-select"
-                value={subStatSort}
-                onChange={(e) => setSubStatSort(e.target.value as StatKey | '')}
-              >
-                <option value="">{t.controls.byScore}</option>
-                {ALL_SUBSTAT_KEYS.map((key) => (
-                  <option key={key} value={key}>
-                    {t.stats[key] ?? STAT_NAMES[key]}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {/* 再構築種別 */}
-            <div className="ctrl-group">
-              <label className="ctrl-label">{t.controls.reconstruction}</label>
-              <select
-                className="ctrl-select"
-                value={reconType}
-                onChange={(e) => setReconType(e.target.value as ReconstructionType)}
-              >
-                {RECON_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </select>
-            </div>
-
-            {/* 再構築成功率ソート */}
-            <div className="ctrl-group">
-              <label className="ctrl-label-toggle">
-                <input
-                  type="checkbox"
-                  className="ctrl-checkbox"
-                  checked={reconSort}
-                  onChange={(e) => setReconSort(e.target.checked)}
-                />
-                {t.controls.bySuccessRate}
-              </label>
-            </div>
-
-            {/* フィルタクリア（常に表示） */}
-            <div className="ctrl-group ctrl-end">
-              <button
-                className="ctrl-btn ctrl-clear"
-                disabled={!hasActiveFilter(filterSets, filterSlot, filterMainStat, filterSubStats, filterInitialOp)}
-                onClick={() => { setFilterSets([]); setFilterSlot(''); setFilterMainStat(''); setFilterSubStats([]); setFilterInitialOp('') }}
-              >
-                {t.controls.filterClear}
-              </button>
-            </div>
-          </div>
-
-          {/* ── カードグリッド ── */}
           <div className="card-grid">
             {displayed.map(({ entry, reconRate }, i) => (
               <ArtifactCard
@@ -471,8 +161,8 @@ export default function HomePage() {
                 entry={entry}
                 scoreType={scoreType}
                 reconRate={reconRate}
-                onFilterBySet={(setKey) => setFilterSets([setKey])}
-                onFilterBySlot={setFilterSlot}
+                onFilterBySet={(setKey) => filters.setFilterSets([setKey])}
+                onFilterBySlot={filters.setFilterSlot}
                 equippedSetKeys={equippedSetsMap.get(entry.artifact.location) ?? []}
               />
             ))}

--- a/webapp/src/components/ControlsBar.tsx
+++ b/webapp/src/components/ControlsBar.tsx
@@ -1,0 +1,312 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { ArtifactSlotKey, ReconstructionType, ScoreTypeName, StatKey } from '@/lib/types'
+import type { ArtifactFiltersHook } from '@/hooks/useArtifactFilters'
+import { useDropdownClose } from '@/hooks/useDropdownClose'
+import { hasActiveFilter } from '@/lib/filterUtils'
+import { ARTIFACT_SET_NAMES, MAIN_STAT_NAMES, STAT_NAMES } from '@/lib/constants'
+import type { Translations } from '@/lib/i18n/types'
+
+const SCORE_TYPE_OPTIONS: ScoreTypeName[] = [
+  'CV', '攻撃型', 'HP型', '防御型', '熟知型', 'チャージ型', '最良型',
+]
+
+const ALL_SUBSTAT_KEYS: StatKey[] = [
+  'critRate_', 'critDMG_', 'atk_', 'hp_', 'def_',
+  'eleMas', 'enerRech_', 'atk', 'hp', 'def',
+]
+
+interface ControlsBarProps {
+  filters: ArtifactFiltersHook
+  scoreType: ScoreTypeName
+  setScoreType: (type: ScoreTypeName) => void
+  subStatSort: StatKey | ''
+  setSubStatSort: (key: StatKey | '') => void
+  reconType: ReconstructionType
+  setReconType: (type: ReconstructionType) => void
+  reconSort: boolean
+  setReconSort: (v: boolean) => void
+  mainStatOptions: string[]
+  setOptionGroups: { label: string; keys: string[] }[]
+  availableSubStatKeys: StatKey[]
+  t: Translations
+  allMainStatNames: Record<string, string>
+}
+
+/** コントロールバー全体コンポーネント */
+export default function ControlsBar({
+  filters,
+  scoreType,
+  setScoreType,
+  subStatSort,
+  setSubStatSort,
+  reconType,
+  setReconType,
+  reconSort,
+  setReconSort,
+  mainStatOptions,
+  setOptionGroups,
+  availableSubStatKeys,
+  t,
+  allMainStatNames,
+}: ControlsBarProps) {
+  const [subStatOpen, setSubStatOpen] = useState(false)
+  const [setFilterOpen, setSetFilterOpen] = useState(false)
+  const subStatBtnRef = useRef<HTMLButtonElement>(null)
+  const subStatPanelRef = useRef<HTMLDivElement>(null)
+  const setFilterBtnRef = useRef<HTMLButtonElement>(null)
+  const setFilterPanelRef = useRef<HTMLDivElement>(null)
+
+  useDropdownClose([
+    {
+      open: subStatOpen,
+      close: () => setSubStatOpen(false),
+      btnRef: subStatBtnRef,
+      panelRef: subStatPanelRef,
+    },
+    {
+      open: setFilterOpen,
+      close: () => setSetFilterOpen(false),
+      btnRef: setFilterBtnRef,
+      panelRef: setFilterPanelRef,
+    },
+  ])
+
+  const RECON_OPTIONS: { value: ReconstructionType; label: string }[] = [
+    { value: 'normal', label: t.reconTypes.normal },
+    { value: 'advanced', label: t.reconTypes.advanced },
+    { value: 'absolute', label: t.reconTypes.absolute },
+  ]
+
+  const SLOT_OPTIONS: { value: ArtifactSlotKey | ''; label: string }[] = [
+    { value: '', label: t.controls.allSlots },
+    { value: 'flower', label: t.slots.flower },
+    { value: 'plume', label: t.slots.plume },
+    { value: 'sands', label: t.slots.sands },
+    { value: 'goblet', label: t.slots.goblet },
+    { value: 'circlet', label: t.slots.circlet },
+  ]
+
+  return (
+    <div className="controls-bar">
+      {/* スコアタイプ */}
+      <div className="ctrl-group">
+        <label className="ctrl-label">{t.controls.scoreType}</label>
+        <select
+          className="ctrl-select"
+          value={scoreType}
+          onChange={(e) => setScoreType(e.target.value as ScoreTypeName)}
+        >
+          {SCORE_TYPE_OPTIONS.map((type) => (
+            <option key={type} value={type}>{t.scoreFormulas[type].label}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* セットフィルタ */}
+      <div className="ctrl-group">
+        <label className="ctrl-label">{t.controls.set}</label>
+        <button
+          ref={setFilterBtnRef}
+          type="button"
+          className="substat-dropdown-btn"
+          onClick={() => setSetFilterOpen((v) => !v)}
+        >
+          {filters.filterSets.length > 0
+            ? `${t.controls.set}(${filters.filterSets.length})`
+            : t.controls.set}
+        </button>
+        {setFilterOpen && createPortal(
+          <div
+            ref={setFilterPanelRef}
+            className="set-dropdown-panel"
+            style={{
+              top: (setFilterBtnRef.current?.getBoundingClientRect().bottom ?? 0) + 4,
+              left: setFilterBtnRef.current?.getBoundingClientRect().left ?? 0,
+            }}
+          >
+            {setOptionGroups.map((group) => {
+              const allSelected = group.keys.every((k) => filters.filterSets.includes(k))
+              const someSelected = group.keys.some((k) => filters.filterSets.includes(k))
+              const groupLabel = t.setGroupLabels[group.label] ?? group.label
+              return (
+                <div key={group.label}>
+                  <label className="set-group-header">
+                    <input
+                      type="checkbox"
+                      className="ctrl-checkbox"
+                      checked={allSelected}
+                      ref={(el) => {
+                        if (el) el.indeterminate = someSelected && !allSelected
+                      }}
+                      onChange={() => filters.toggleSetGroup(group.keys, allSelected)}
+                    />
+                    {groupLabel}
+                  </label>
+                  {group.keys.map((key) => (
+                    <label key={key} className="substat-dropdown-item set-item">
+                      <input
+                        type="checkbox"
+                        className="ctrl-checkbox"
+                        checked={filters.filterSets.includes(key)}
+                        onChange={(e) => filters.toggleSet(key, e.target.checked)}
+                      />
+                      {t.artifactSetNames[key] ?? ARTIFACT_SET_NAMES[key] ?? key}
+                    </label>
+                  ))}
+                </div>
+              )
+            })}
+          </div>,
+          document.body,
+        )}
+      </div>
+
+      {/* 部位フィルタ */}
+      <div className="ctrl-group">
+        <label className="ctrl-label">{t.controls.slot}</label>
+        <select
+          className="ctrl-select"
+          value={filters.filterSlot}
+          onChange={(e) => filters.setFilterSlot(e.target.value as ArtifactSlotKey | '')}
+        >
+          {SLOT_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* メインステフィルタ */}
+      <div className="ctrl-group">
+        <label className="ctrl-label">{t.controls.mainStat}</label>
+        <select
+          className="ctrl-select"
+          value={filters.filterMainStat}
+          onChange={(e) => filters.applyMainStat(e.target.value)}
+        >
+          <option value="">{t.controls.allMainStats}</option>
+          {mainStatOptions.map((key) => (
+            <option key={key} value={key}>
+              {allMainStatNames[key] ?? MAIN_STAT_NAMES[key] ?? key}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* 初期OPフィルタ */}
+      <div className="ctrl-group">
+        <label className="ctrl-label">{t.controls.initialOp}</label>
+        <select
+          className="ctrl-select"
+          value={filters.filterInitialOp}
+          onChange={(e) => filters.setFilterInitialOp(e.target.value as '' | '3' | '4')}
+        >
+          <option value="">{t.controls.allOps}</option>
+          <option value="3">{t.controls.op3}</option>
+          <option value="4">{t.controls.op4}</option>
+        </select>
+      </div>
+
+      {/* サブステフィルタ */}
+      <div className="ctrl-group">
+        <label className="ctrl-label">{t.controls.substatFilter}</label>
+        <button
+          ref={subStatBtnRef}
+          type="button"
+          className="substat-dropdown-btn"
+          onClick={() => setSubStatOpen((v) => !v)}
+        >
+          {filters.filterSubStats.length > 0
+            ? `${t.controls.substatBtn}(${filters.filterSubStats.length})`
+            : t.controls.substatBtn}
+        </button>
+        {subStatOpen && createPortal(
+          <div
+            ref={subStatPanelRef}
+            className="substat-dropdown-panel"
+            style={{
+              top: (subStatBtnRef.current?.getBoundingClientRect().bottom ?? 0) + 4,
+              left: subStatBtnRef.current?.getBoundingClientRect().left ?? 0,
+            }}
+          >
+            {availableSubStatKeys.map((key) => (
+              <label key={key} className="substat-dropdown-item">
+                <input
+                  type="checkbox"
+                  className="ctrl-checkbox"
+                  checked={filters.filterSubStats.includes(key)}
+                  onChange={(e) => filters.toggleSubStat(key, e.target.checked)}
+                />
+                {t.stats[key] ?? STAT_NAMES[key]}
+              </label>
+            ))}
+          </div>,
+          document.body,
+        )}
+      </div>
+
+      {/* サブステソート */}
+      <div className="ctrl-group">
+        <label className="ctrl-label">{t.controls.substatSort}</label>
+        <select
+          className="ctrl-select"
+          value={subStatSort}
+          onChange={(e) => setSubStatSort(e.target.value as StatKey | '')}
+        >
+          <option value="">{t.controls.byScore}</option>
+          {ALL_SUBSTAT_KEYS.map((key) => (
+            <option key={key} value={key}>
+              {t.stats[key] ?? STAT_NAMES[key]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* 再構築種別 */}
+      <div className="ctrl-group">
+        <label className="ctrl-label">{t.controls.reconstruction}</label>
+        <select
+          className="ctrl-select"
+          value={reconType}
+          onChange={(e) => setReconType(e.target.value as ReconstructionType)}
+        >
+          {RECON_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* 再構築成功率ソート */}
+      <div className="ctrl-group">
+        <label className="ctrl-label-toggle">
+          <input
+            type="checkbox"
+            className="ctrl-checkbox"
+            checked={reconSort}
+            onChange={(e) => setReconSort(e.target.checked)}
+          />
+          {t.controls.bySuccessRate}
+        </label>
+      </div>
+
+      {/* フィルタクリア */}
+      <div className="ctrl-group ctrl-end">
+        <button
+          className="ctrl-btn ctrl-clear"
+          disabled={!hasActiveFilter(
+            filters.filterSets,
+            filters.filterSlot,
+            filters.filterMainStat,
+            filters.filterSubStats,
+            filters.filterInitialOp,
+          )}
+          onClick={filters.resetFilters}
+        >
+          {t.controls.filterClear}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/components/HeroSection.tsx
+++ b/webapp/src/components/HeroSection.tsx
@@ -1,0 +1,31 @@
+import FileUpload from '@/components/FileUpload'
+import type { GoodFile, ScoreTypeName } from '@/lib/types'
+import type { Translations } from '@/lib/i18n/types'
+
+interface HeroSectionProps {
+  onLoad: (data: GoodFile) => void
+  t: Translations
+  scoreTypeOptions: ScoreTypeName[]
+}
+
+/** アップロード画面（空状態）の Hero セクション */
+export default function HeroSection({ onLoad, t, scoreTypeOptions }: HeroSectionProps) {
+  return (
+    <div className="hero-section">
+      <FileUpload onLoad={onLoad} />
+      {/* スコア計算式の説明 */}
+      <div className="score-formulas">
+        <p className="score-formulas-title">{t.pages.aboutScore.formulaList.heading}</p>
+        <ul className="score-formulas-list">
+          {scoreTypeOptions.map((type) => (
+            <li key={type} className="score-formulas-item">
+              <span className="score-formulas-label">{t.scoreFormulas[type].label}</span>
+              <span className="score-formulas-eq">=</span>
+              <span className="score-formulas-formula">{t.scoreFormulas[type].formula}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/hooks/useArtifactFilters.ts
+++ b/webapp/src/hooks/useArtifactFilters.ts
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+import type { ArtifactSlotKey, StatKey } from '@/lib/types'
+import {
+  type ArtifactFilterState,
+  INITIAL_ARTIFACT_FILTER_STATE,
+  resetArtifactFilters,
+  setMainStatFilter,
+  toggleSubStatFilter,
+  toggleSetFilter,
+  toggleSetGroupFilter,
+} from '@/lib/artifactFilters'
+
+export type { ArtifactFilterState }
+
+export interface ArtifactFiltersHook extends ArtifactFilterState {
+  setFilterSets: (sets: string[]) => void
+  setFilterSlot: (slot: ArtifactSlotKey | '') => void
+  setFilterInitialOp: (op: '' | '3' | '4') => void
+  resetFilters: () => void
+  applyMainStat: (value: string) => void
+  toggleSubStat: (key: StatKey, checked: boolean) => void
+  toggleSet: (key: string, checked: boolean) => void
+  toggleSetGroup: (keys: string[], allSelected: boolean) => void
+}
+
+/** フィルタ状態を一元管理するカスタムフック */
+export function useArtifactFilters(): ArtifactFiltersHook {
+  const [state, setState] = useState<ArtifactFilterState>(INITIAL_ARTIFACT_FILTER_STATE)
+
+  return {
+    ...state,
+    setFilterSets: (sets) => setState((prev) => ({ ...prev, filterSets: sets })),
+    setFilterSlot: (slot) => setState((prev) => ({ ...prev, filterSlot: slot })),
+    setFilterInitialOp: (op) => setState((prev) => ({ ...prev, filterInitialOp: op })),
+    resetFilters: () => setState(resetArtifactFilters()),
+    applyMainStat: (value) => setState((prev) => setMainStatFilter(prev, value)),
+    toggleSubStat: (key, checked) => setState((prev) => toggleSubStatFilter(prev, key, checked)),
+    toggleSet: (key, checked) => setState((prev) => toggleSetFilter(prev, key, checked)),
+    toggleSetGroup: (keys, allSelected) =>
+      setState((prev) => toggleSetGroupFilter(prev, keys, allSelected)),
+  }
+}

--- a/webapp/src/hooks/useDropdownClose.ts
+++ b/webapp/src/hooks/useDropdownClose.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react'
+import { isOutsideDropdown } from '@/lib/dropdownUtils'
+
+interface DropdownEntry {
+  open: boolean
+  close: () => void
+  btnRef: { current: Element | null }
+  panelRef: { current: Element | null }
+}
+
+/**
+ * 外側クリック・Escキーでドロップダウンを閉じる共通フック
+ * @param dropdowns 管理対象のドロップダウン一覧
+ */
+export function useDropdownClose(dropdowns: DropdownEntry[]): void {
+  const anyOpen = dropdowns.some((d) => d.open)
+
+  useEffect(() => {
+    if (!anyOpen) return
+
+    function handleClick(e: MouseEvent) {
+      const target = e.target as Node
+      for (const { open, close, btnRef, panelRef } of dropdowns) {
+        if (open && isOutsideDropdown(target, btnRef.current, panelRef.current)) {
+          close()
+        }
+      }
+    }
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        for (const { close } of dropdowns) {
+          close()
+        }
+      }
+    }
+
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [anyOpen])
+}

--- a/webapp/src/lib/__tests__/artifactFilters.test.ts
+++ b/webapp/src/lib/__tests__/artifactFilters.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import {
+  INITIAL_ARTIFACT_FILTER_STATE,
+  resetArtifactFilters,
+  setMainStatFilter,
+  toggleSubStatFilter,
+  toggleSetFilter,
+  toggleSetGroupFilter,
+} from '@/lib/artifactFilters'
+
+describe('INITIAL_ARTIFACT_FILTER_STATE', () => {
+  it('すべてのフィルタが未設定の初期値を持つ', () => {
+    expect(INITIAL_ARTIFACT_FILTER_STATE).toEqual({
+      filterSets: [],
+      filterSlot: '',
+      filterMainStat: '',
+      filterSubStats: [],
+      filterInitialOp: '',
+    })
+  })
+})
+
+describe('resetArtifactFilters', () => {
+  it('フィルタ設定済み状態から初期値を返す', () => {
+    expect(resetArtifactFilters()).toEqual(INITIAL_ARTIFACT_FILTER_STATE)
+  })
+
+  it('毎回新しいオブジェクトを返す', () => {
+    const a = resetArtifactFilters()
+    const b = resetArtifactFilters()
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('setMainStatFilter', () => {
+  it('メインステを設定する', () => {
+    const state = { ...INITIAL_ARTIFACT_FILTER_STATE }
+    const next = setMainStatFilter(state, 'critRate_')
+    expect(next.filterMainStat).toBe('critRate_')
+  })
+
+  it('メインステと同じキーをサブステフィルタから除外する', () => {
+    const state = {
+      ...INITIAL_ARTIFACT_FILTER_STATE,
+      filterSubStats: ['critRate_', 'critDMG_'] as const,
+    }
+    const next = setMainStatFilter(state, 'critRate_')
+    expect(next.filterSubStats).toEqual(['critDMG_'])
+  })
+
+  it('メインステをリセット（空文字）できる', () => {
+    const state = { ...INITIAL_ARTIFACT_FILTER_STATE, filterMainStat: 'critRate_' }
+    const next = setMainStatFilter(state, '')
+    expect(next.filterMainStat).toBe('')
+  })
+
+  it('他のフィルタ状態を変更しない', () => {
+    const state = {
+      ...INITIAL_ARTIFACT_FILTER_STATE,
+      filterSets: ['GladiatorsFinale'],
+      filterSlot: 'flower' as const,
+    }
+    const next = setMainStatFilter(state, 'critRate_')
+    expect(next.filterSets).toEqual(['GladiatorsFinale'])
+    expect(next.filterSlot).toBe('flower')
+  })
+})
+
+describe('toggleSubStatFilter', () => {
+  it('checked=true のときサブステを追加する', () => {
+    const state = { ...INITIAL_ARTIFACT_FILTER_STATE }
+    const next = toggleSubStatFilter(state, 'critDMG_', true)
+    expect(next.filterSubStats).toContain('critDMG_')
+  })
+
+  it('checked=false のときサブステを削除する', () => {
+    const state = {
+      ...INITIAL_ARTIFACT_FILTER_STATE,
+      filterSubStats: ['critDMG_', 'atk_'] as const,
+    }
+    const next = toggleSubStatFilter(state, 'critDMG_', false)
+    expect(next.filterSubStats).not.toContain('critDMG_')
+    expect(next.filterSubStats).toContain('atk_')
+  })
+
+  it('他のフィルタ状態を変更しない', () => {
+    const state = {
+      ...INITIAL_ARTIFACT_FILTER_STATE,
+      filterMainStat: 'atk',
+    }
+    const next = toggleSubStatFilter(state, 'critDMG_', true)
+    expect(next.filterMainStat).toBe('atk')
+  })
+})
+
+describe('toggleSetFilter', () => {
+  it('checked=true のときセットを追加する', () => {
+    const state = { ...INITIAL_ARTIFACT_FILTER_STATE }
+    const next = toggleSetFilter(state, 'GladiatorsFinale', true)
+    expect(next.filterSets).toContain('GladiatorsFinale')
+  })
+
+  it('checked=false のときセットを削除する', () => {
+    const state = {
+      ...INITIAL_ARTIFACT_FILTER_STATE,
+      filterSets: ['GladiatorsFinale', 'BlizzardStrayer'],
+    }
+    const next = toggleSetFilter(state, 'GladiatorsFinale', false)
+    expect(next.filterSets).not.toContain('GladiatorsFinale')
+    expect(next.filterSets).toContain('BlizzardStrayer')
+  })
+})
+
+describe('toggleSetGroupFilter', () => {
+  it('allSelected=false のとき未選択キーを追加する', () => {
+    const state = { ...INITIAL_ARTIFACT_FILTER_STATE }
+    const next = toggleSetGroupFilter(state, ['SetA', 'SetB'], false)
+    expect(next.filterSets).toEqual(['SetA', 'SetB'])
+  })
+
+  it('allSelected=true のときグループ内キーをすべて削除する', () => {
+    const state = {
+      ...INITIAL_ARTIFACT_FILTER_STATE,
+      filterSets: ['SetA', 'SetB', 'SetC'],
+    }
+    const next = toggleSetGroupFilter(state, ['SetA', 'SetB'], true)
+    expect(next.filterSets).toEqual(['SetC'])
+  })
+
+  it('既に選択済みのキーを重複追加しない', () => {
+    const state = {
+      ...INITIAL_ARTIFACT_FILTER_STATE,
+      filterSets: ['SetA'],
+    }
+    const next = toggleSetGroupFilter(state, ['SetA', 'SetB'], false)
+    expect(next.filterSets).toEqual(['SetA', 'SetB'])
+  })
+})

--- a/webapp/src/lib/__tests__/dropdownUtils.test.ts
+++ b/webapp/src/lib/__tests__/dropdownUtils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { isOutsideDropdown } from '@/lib/dropdownUtils'
+
+const makeEl = (contains: boolean) =>
+  ({ contains: () => contains }) as unknown as Element
+
+describe('isOutsideDropdown', () => {
+  it('ボタン内クリックのとき false を返す', () => {
+    const target = {} as Node
+    expect(isOutsideDropdown(target, makeEl(true), makeEl(false))).toBe(false)
+  })
+
+  it('パネル内クリックのとき false を返す', () => {
+    const target = {} as Node
+    expect(isOutsideDropdown(target, makeEl(false), makeEl(true))).toBe(false)
+  })
+
+  it('ボタンもパネルも外のクリックのとき true を返す', () => {
+    const target = {} as Node
+    expect(isOutsideDropdown(target, makeEl(false), makeEl(false))).toBe(true)
+  })
+
+  it('btnEl が null のとき true を返す（panelEl が外の場合）', () => {
+    const target = {} as Node
+    expect(isOutsideDropdown(target, null, makeEl(false))).toBe(true)
+  })
+
+  it('panelEl が null のとき true を返す（btnEl が外の場合）', () => {
+    const target = {} as Node
+    expect(isOutsideDropdown(target, makeEl(false), null)).toBe(true)
+  })
+
+  it('btnEl も panelEl も null のとき true を返す', () => {
+    const target = {} as Node
+    expect(isOutsideDropdown(target, null, null)).toBe(true)
+  })
+})

--- a/webapp/src/lib/artifactFilters.ts
+++ b/webapp/src/lib/artifactFilters.ts
@@ -1,0 +1,80 @@
+import type { ArtifactSlotKey, StatKey } from '@/lib/types'
+
+/** フィルタ状態 */
+export interface ArtifactFilterState {
+  filterSets: string[]
+  filterSlot: ArtifactSlotKey | ''
+  filterMainStat: string
+  filterSubStats: StatKey[]
+  filterInitialOp: '' | '3' | '4'
+}
+
+export const INITIAL_ARTIFACT_FILTER_STATE: ArtifactFilterState = {
+  filterSets: [],
+  filterSlot: '',
+  filterMainStat: '',
+  filterSubStats: [],
+  filterInitialOp: '',
+}
+
+/** フィルタをすべてリセットした新しい状態を返す */
+export function resetArtifactFilters(): ArtifactFilterState {
+  return { ...INITIAL_ARTIFACT_FILTER_STATE }
+}
+
+/** メインステを設定し、同一キーをサブステフィルタから除外する */
+export function setMainStatFilter(
+  state: ArtifactFilterState,
+  value: string,
+): ArtifactFilterState {
+  return {
+    ...state,
+    filterMainStat: value,
+    filterSubStats: state.filterSubStats.filter((k) => k !== value),
+  }
+}
+
+/** サブステフィルタのトグル */
+export function toggleSubStatFilter(
+  state: ArtifactFilterState,
+  key: StatKey,
+  checked: boolean,
+): ArtifactFilterState {
+  return {
+    ...state,
+    filterSubStats: checked
+      ? [...state.filterSubStats, key]
+      : state.filterSubStats.filter((k) => k !== key),
+  }
+}
+
+/** 単一セットフィルタのトグル */
+export function toggleSetFilter(
+  state: ArtifactFilterState,
+  key: string,
+  checked: boolean,
+): ArtifactFilterState {
+  return {
+    ...state,
+    filterSets: checked
+      ? [...state.filterSets, key]
+      : state.filterSets.filter((k) => k !== key),
+  }
+}
+
+/**
+ * セットグループのトグル
+ * allSelected=true なら全削除、false なら未選択分を追加
+ */
+export function toggleSetGroupFilter(
+  state: ArtifactFilterState,
+  keys: string[],
+  allSelected: boolean,
+): ArtifactFilterState {
+  return {
+    ...state,
+    filterSets: allSelected
+      ? state.filterSets.filter((k) => !keys.includes(k))
+      : [...state.filterSets, ...keys.filter((k) => !state.filterSets.includes(k))],
+  }
+}

--- a/webapp/src/lib/dropdownUtils.ts
+++ b/webapp/src/lib/dropdownUtils.ts
@@ -1,0 +1,13 @@
+/**
+ * クリックターゲットがドロップダウン（ボタン＋パネル）の外かどうかを返す
+ * true → 外側クリック → ドロップダウンを閉じる
+ */
+export function isOutsideDropdown(
+  target: Node,
+  btnEl: Element | null,
+  panelEl: Element | null,
+): boolean {
+  if (btnEl?.contains(target)) return false
+  if (panelEl?.contains(target)) return false
+  return true
+}


### PR DESCRIPTION
Closes #81

## 変更内容

- `useArtifactFilters` カスタムフックを追加（フィルタ状態を一元管理）
- `useDropdownClose` カスタムフックを追加（外側クリック・Escキーで閉じる共通処理）
- `HeroSection` コンポーネントを抽出
- `ControlsBar` コンポーネントを抽出
- `page.tsx` を 485 行 → 174 行 に削減
- 純粋関数の TDD テストを追加

Generated with [Claude Code](https://claude.ai/code)