### PR TITLE
fix: replace undefined filter variables with filters.* in displayed useMemo

### DIFF
--- a/webapp/src/app/page.tsx
+++ b/webapp/src/app/page.tsx
@@ -99,9 +99,9 @@ export default function HomePage() {
     if (!allRanked) return []
     return allRanked
       .map((e, i) => ({ entry: e, reconRate: reconRates.get(i) ?? null, originalIndex: i }))
-      .filter(({ entry: e }) => filterSets.length === 0 || filterSets.includes(e.artifact.setKey))
-      .filter(({ entry: e }) => !filterSlot || e.artifact.slotKey === filterSlot)
-      .filter(({ entry: e }) => !filterMainStat || e.artifact.mainStatKey === filterMainStat)
+      .filter(({ entry: e }) => filters.filterSets.length === 0 || filters.filterSets.includes(e.artifact.setKey))
+      .filter(({ entry: e }) => !filters.filterSlot || e.artifact.slotKey === filters.filterSlot)
+      .filter(({ entry: e }) => !filters.filterMainStat || e.artifact.mainStatKey === filters.filterMainStat)
       .filter(({ entry: e }) =>
         filters.filterSubStats.length === 0 ||
         filters.filterSubStats.every((k) => e.artifact.substats.some((s) => s.key === k)),


### PR DESCRIPTION
filterSets, filterSlot, filterMainStat were referenced as bare variables in the displayed useMemo but were never defined in scope. Replace them with filters.filterSets, filters.filterSlot, filters.filterMainStat.

Closes #86

Generated with [Claude Code](https://claude.ai/code)