### PR TITLE
refactor: consolidate duplicate constants into constants.ts

### DIFF
--- a/webapp/src/app/page.tsx
+++ b/webapp/src/app/page.tsx
@@ -7,18 +7,9 @@ import ControlsBar from '@/components/ControlsBar'
 import type { GoodFile, RankedArtifact, ReconstructionType, ScoreTypeName, StatKey } from '@/lib/types'
 import { calculateAllScores, calculateScores, estimateRollCounts } from '@/lib/scoring'
 import { calculateReconstructionRate } from '@/lib/reconstruction'
-import { groupSetOptions } from '@/lib/constants'
+import { groupSetOptions, SCORE_TYPE_OPTIONS, ALL_SUBSTAT_KEYS } from '@/lib/constants'
 import { useTranslation } from '@/lib/i18n'
 import { useArtifactFilters } from '@/hooks/useArtifactFilters'
-
-const SCORE_TYPE_OPTIONS: ScoreTypeName[] = [
-  'CV', '攻撃型', 'HP型', '防御型', '熟知型', 'チャージ型', '最良型',
-]
-
-const ALL_SUBSTAT_KEYS: StatKey[] = [
-  'critRate_', 'critDMG_', 'atk_', 'hp_', 'def_',
-  'eleMas', 'enerRech_', 'atk', 'hp', 'def',
-]
 
 const MAIN_STAT_ORDER: string[] = [
   'critRate_', 'critDMG_', 'atk_', 'hp_', 'def_',

--- a/webapp/src/components/ControlsBar.tsx
+++ b/webapp/src/components/ControlsBar.tsx
@@ -6,17 +6,8 @@ import type { ArtifactSlotKey, ReconstructionType, ScoreTypeName, StatKey } from
 import type { ArtifactFiltersHook } from '@/hooks/useArtifactFilters'
 import { useDropdownClose } from '@/hooks/useDropdownClose'
 import { hasActiveFilter } from '@/lib/filterUtils'
-import { ARTIFACT_SET_NAMES, MAIN_STAT_NAMES, STAT_NAMES } from '@/lib/constants'
+import { ARTIFACT_SET_NAMES, MAIN_STAT_NAMES, STAT_NAMES, SCORE_TYPE_OPTIONS, ALL_SUBSTAT_KEYS } from '@/lib/constants'
 import type { Translations } from '@/lib/i18n/types'
-
-const SCORE_TYPE_OPTIONS: ScoreTypeName[] = [
-  'CV', '攻撃型', 'HP型', '防御型', '熟知型', 'チャージ型', '最良型',
-]
-
-const ALL_SUBSTAT_KEYS: StatKey[] = [
-  'critRate_', 'critDMG_', 'atk_', 'hp_', 'def_',
-  'eleMas', 'enerRech_', 'atk', 'hp', 'def',
-]
 
 interface ControlsBarProps {
   filters: ArtifactFiltersHook

--- a/webapp/src/lib/constants.ts
+++ b/webapp/src/lib/constants.ts
@@ -2,6 +2,17 @@
 
 import type { ArtifactSlotKey, ScoreTypeName, StatKey } from './types'
 
+/** スコアタイプの選択肢一覧 */
+export const SCORE_TYPE_OPTIONS: ScoreTypeName[] = [
+  'CV', '攻撃型', 'HP型', '防御型', '熟知型', 'チャージ型', '最良型',
+]
+
+/** サブステータスのキー一覧 */
+export const ALL_SUBSTAT_KEYS: StatKey[] = [
+  'critRate_', 'critDMG_', 'atk_', 'hp_', 'def_',
+  'eleMas', 'enerRech_', 'atk', 'hp', 'def',
+]
+
 /** 各スコアタイプの表示ラベルと計算式 */
 export const SCORE_TYPE_FORMULAS: Record<ScoreTypeName, { label: string; formula: string }> = {
   CV: { label: 'CVスコア', formula: '会心率×2 + 会心ダメージ' },


### PR DESCRIPTION
SCORE_TYPE_OPTIONS と ALL_SUBSTAT_KEYS の重複定義を constants.ts に一元化。page.tsx と ControlsBar.tsx からインポートする形に変更。

Closes #127

Generated with [Claude Code](https://claude.ai/code)