### PR TITLE
fix: resolve stale closure risk in useDropdownClose with useRef

### DIFF
--- a/webapp/src/hooks/useDropdownClose.ts
+++ b/webapp/src/hooks/useDropdownClose.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { isOutsideDropdown } from '@/lib/dropdownUtils'
 
 interface DropdownEntry {
@@ -14,13 +14,15 @@ interface DropdownEntry {
  */
 export function useDropdownClose(dropdowns: DropdownEntry[]): void {
   const anyOpen = dropdowns.some((d) => d.open)
+  const dropdownsRef = useRef(dropdowns)
+  dropdownsRef.current = dropdowns
 
   useEffect(() => {
     if (!anyOpen) return
 
     function handleClick(e: MouseEvent) {
       const target = e.target as Node
-      for (const { open, close, btnRef, panelRef } of dropdowns) {
+      for (const { open, close, btnRef, panelRef } of dropdownsRef.current) {
         if (open && isOutsideDropdown(target, btnRef.current, panelRef.current)) {
           close()
         }
@@ -29,7 +31,7 @@ export function useDropdownClose(dropdowns: DropdownEntry[]): void {
 
     function handleKey(e: KeyboardEvent) {
       if (e.key === 'Escape') {
-        for (const { close } of dropdowns) {
+        for (const { close } of dropdownsRef.current) {
           close()
         }
       }
@@ -41,6 +43,5 @@ export function useDropdownClose(dropdowns: DropdownEntry[]): void {
       document.removeEventListener('mousedown', handleClick)
       document.removeEventListener('keydown', handleKey)
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [anyOpen])
 }

--- a/webapp/src/lib/__tests__/useDropdownClose.test.ts
+++ b/webapp/src/lib/__tests__/useDropdownClose.test.ts
@@ -97,6 +97,30 @@ describe('useDropdownClose', () => {
     expect(dropdown.close).not.toHaveBeenCalled()
   })
 
+  it('再レンダー後の新しい close 関数が呼ばれる（ストールクロージャなし）', () => {
+    const oldClose = vi.fn()
+    const newClose = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ closeFn }) =>
+        useDropdownClose([
+          {
+            open: true,
+            close: closeFn,
+            btnRef: makeRef(false),
+            panelRef: makeRef(false),
+          },
+        ]),
+      { initialProps: { closeFn: oldClose } },
+    )
+
+    rerender({ closeFn: newClose })
+    document.dispatchEvent(new MouseEvent('mousedown'))
+
+    expect(newClose).toHaveBeenCalledTimes(1)
+    expect(oldClose).not.toHaveBeenCalled()
+  })
+
   it('アンマウント時にイベントリスナーが削除される', () => {
     const dropdown = makeDropdown(true)
 


### PR DESCRIPTION
useRefを使った"ref trick"パターンでストールクロージャリスクを修正します。

## 変更内容

- `useDropdownClose.ts`: `dropdownsRef` で最新のdropdownsを常に保持、`eslint-disable`コメントを削除
- `useDropdownClose.test.ts`: ストールクロージャなしを確認するテストを追加

Closes #128

Generated with [Claude Code](https://claude.ai/code)