### PR TITLE
fix: clip negative initial values in reconstruction.ts

### DIFF
--- a/webapp/src/lib/reconstruction.ts
+++ b/webapp/src/lib/reconstruction.ts
@@ -209,8 +209,10 @@ function calcRateForPair(
   for (const s of substats) currentSubMap[s.key] = s.value
   const currentScore = calcScore(currentSubMap, scoreType)
 
-  // 初期ロール値を推定: 現在値 - 平均強化幅 × 強化ロール数
-  const initialValues = substats.map((s, i) => s.value - AVG_INCREMENT[s.key] * rollCounts[i])
+  // 初期ロール値を推定: 現在値 - 平均強化幅 × 強化ロール数（負にならないようクリッピング）
+  const initialValues = substats.map((s, i) =>
+    Math.max(0, s.value - AVG_INCREMENT[s.key] * rollCounts[i])
+  )
 
   // 全パターンを列挙して保証フィルタ → スコア比較
   const patterns = enumeratePatterns(4, enhTotal)


### PR DESCRIPTION
reconstruction.ts L213 の initialValues 計算に Math.max(0, ...) クリッピングを追加。rollCounts の推定見が過大な場合でも initialValues が負にならず、不正なスコア計算や再構築成功率のずれを防ぐ。

Closes #132

Generated with [Claude Code](https://claude.ai/code)