### PR TITLE
feat: add file size validation to FileUpload component

### DIFF
--- a/webapp/src/components/FileUpload.tsx
+++ b/webapp/src/components/FileUpload.tsx
@@ -16,6 +16,11 @@ export default function FileUpload({ onLoad }: FileUploadProps) {
 
   function parseFile(file: File) {
     setError(null)
+    const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
+    if (file.size > MAX_FILE_SIZE) {
+      setError(t.upload.errorSize)
+      return
+    }
     const reader = new FileReader()
     reader.onload = (e) => {
       try {

--- a/webapp/src/lib/__tests__/FileUpload.test.tsx
+++ b/webapp/src/lib/__tests__/FileUpload.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import FileUpload from '@/components/FileUpload'
+import { LanguageProvider } from '@/lib/i18n'
+
+function renderFileUpload(onLoad = vi.fn()) {
+  return render(
+    <LanguageProvider>
+      <FileUpload onLoad={onLoad} />
+    </LanguageProvider>,
+  )
+}
+
+function makeFile(name: string, size: number, content = '{}') {
+  const file = new File([content], name, { type: 'application/json' })
+  Object.defineProperty(file, 'size', { value: size })
+  return file
+}
+
+describe('FileUpload', () => {
+  it('ファイルサイズが10MB以下の場合はエラーなし', () => {
+    renderFileUpload()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = makeFile('test.json', 1024, JSON.stringify({ format: 'GOOD', artifacts: [] }))
+    fireEvent.change(input, { target: { files: [file] } })
+    expect(screen.queryByText(/ファイルサイズが大きすぎます/)).toBeNull()
+  })
+
+  it('ファイルサイズが10MBを超える場合はエラーメッセージを表示する', () => {
+    renderFileUpload()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const oversizedFile = makeFile('huge.json', 11 * 1024 * 1024)
+    fireEvent.change(input, { target: { files: [oversizedFile] } })
+    expect(screen.getByText('ファイルサイズが大きすぎます（上限: 10MB）')).toBeTruthy()
+  })
+
+  it('ファイルサイズが10MBを超える場合はonLoadを呼ばない', () => {
+    const onLoad = vi.fn()
+    renderFileUpload(onLoad)
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const oversizedFile = makeFile('huge.json', 11 * 1024 * 1024)
+    fireEvent.change(input, { target: { files: [oversizedFile] } })
+    expect(onLoad).not.toHaveBeenCalled()
+  })
+})

--- a/webapp/src/lib/i18n/en.ts
+++ b/webapp/src/lib/i18n/en.ts
@@ -131,6 +131,7 @@ export const en: Translations = {
     click: 'or click to select JSON',
     errorFormat: 'Please select a GOOD format JSON file',
     errorParse: 'Failed to parse JSON',
+    errorSize: 'File size is too large (limit: 10MB)',
   },
 
   controls: {

--- a/webapp/src/lib/i18n/ja.ts
+++ b/webapp/src/lib/i18n/ja.ts
@@ -71,6 +71,7 @@ export const ja: Translations = {
     click: 'またはクリックしてJSONを選択',
     errorFormat: 'GOODフォーマットのJSONを選択してください',
     errorParse: 'JSONの解析に失敗しました',
+    errorSize: 'ファイルサイズが大きすぎます（上限: 10MB）',
   },
 
   controls: {

--- a/webapp/src/lib/i18n/types.ts
+++ b/webapp/src/lib/i18n/types.ts
@@ -31,6 +31,7 @@ export interface Translations {
     click: string
     errorFormat: string
     errorParse: string
+    errorSize: string
   }
 
   controls: {


### PR DESCRIPTION
FileUpload コンポーネントに 10MB のファイルサイズ上限チェックを追加し、巨大な JSON ファイルによるブラウザフリーズを防止します。

Closes #130

Generated with [Claude Code](https://claude.ai/code)