### PR TITLE
fix: validate file MIME type and extension before parsing

### DIFF
--- a/webapp/src/components/FileUpload.tsx
+++ b/webapp/src/components/FileUpload.tsx
@@ -16,6 +16,10 @@ export default function FileUpload({ onLoad }: FileUploadProps) {
 
   function parseFile(file: File) {
     setError(null)
+    if (file.type !== 'application/json' && !file.name.endsWith('.json')) {
+      setError(t.upload.errorFormat)
+      return
+    }
     const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
     if (file.size > MAX_FILE_SIZE) {
       setError(t.upload.errorSize)

--- a/webapp/src/lib/__tests__/FileUpload.test.tsx
+++ b/webapp/src/lib/__tests__/FileUpload.test.tsx
@@ -13,13 +13,38 @@ function renderFileUpload(onLoad = vi.fn()) {
   )
 }
 
-function makeFile(name: string, size: number, content = '{}') {
-  const file = new File([content], name, { type: 'application/json' })
+function makeFile(name: string, size: number, content = '{}', type = 'application/json') {
+  const file = new File([content], name, { type })
   Object.defineProperty(file, 'size', { value: size })
   return file
 }
 
 describe('FileUpload', () => {
+  it('非JSONファイルをドロップした場合はフォーマットエラーを表示する', () => {
+    renderFileUpload()
+    const zone = document.querySelector('.upload-zone') as HTMLElement
+    const badFile = makeFile('malware.exe', 1024, 'binary', 'application/octet-stream')
+    fireEvent.drop(zone, { dataTransfer: { files: [badFile] } })
+    expect(screen.getByText('GOODフォーマットのJSONを選択してください')).toBeTruthy()
+  })
+
+  it('非JSONファイルをドロップした場合はonLoadを呼ばない', () => {
+    const onLoad = vi.fn()
+    renderFileUpload(onLoad)
+    const zone = document.querySelector('.upload-zone') as HTMLElement
+    const badFile = makeFile('malware.exe', 1024, 'binary', 'application/octet-stream')
+    fireEvent.drop(zone, { dataTransfer: { files: [badFile] } })
+    expect(onLoad).not.toHaveBeenCalled()
+  })
+
+  it('拡張子が.jsonであればMIMEタイプがなくても受け付ける', () => {
+    renderFileUpload()
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = makeFile('test.json', 1024, JSON.stringify({ format: 'GOOD', artifacts: [] }), '')
+    fireEvent.change(input, { target: { files: [file] } })
+    expect(screen.queryByText('GOODフォーマットのJSONを選択してください')).toBeNull()
+  })
+
   it('ファイルサイズが10MB以下の場合はエラーなし', () => {
     renderFileUpload()
     const input = document.querySelector('input[type="file"]') as HTMLInputElement


### PR DESCRIPTION
MIMEタイプ・拡張子の検証を`FileUpload.tsx`の`parseFile`関数に追加しました。

ドラッグ&ドロップ経由で`.json`以外のファイルが`JSON.parse`に渡される問題を防ぎます。

Closes #145

Generated with [Claude Code](https://claude.ai/code)