### PR TITLE
fix: add totalRolls upper bound to prevent computation DoS

### DIFF
--- a/webapp/src/lib/__tests__/reconstruction.test.ts
+++ b/webapp/src/lib/__tests__/reconstruction.test.ts
@@ -207,6 +207,14 @@ describe('calculateReconstructionRate', () => {
     expect(calculateReconstructionRate(artLv16, [2, 1, 1, 1], 'CV', 'normal')).toBeNull()
   })
 
+  it('totalRolls > 20 の場合は null を返す（DoS 防止）', () => {
+    const art = makeArtifact({ totalRolls: 21 })
+    expect(calculateReconstructionRate(art, [2, 1, 1, 1], 'CV', 'normal')).toBeNull()
+
+    const artExcessive = makeArtifact({ totalRolls: 1000 })
+    expect(calculateReconstructionRate(artExcessive, [250, 250, 250, 250], 'CV', 'normal')).toBeNull()
+  })
+
   it('保証サブステが揃わない場合は null', () => {
     const art = makeArtifact({
       substats: [

--- a/webapp/src/lib/reconstruction.ts
+++ b/webapp/src/lib/reconstruction.ts
@@ -168,6 +168,9 @@ export function calculateReconstructionRate(
   // ★5 Lv.20 以外は対象外
   if (artifact.rarity !== 5 || artifact.level !== 20) return null
 
+  // totalRolls 上限チェック（DoS 防止: enumeratePatterns の計算量爆発を防ぐ）
+  if (artifact.totalRolls > 20) return null
+
   const { substats } = artifact
   if (substats.length !== 4) return null
 


### PR DESCRIPTION
totalRolls > 20 の場合に calculateReconstructionRate が null を返すバリデーションを追加。enumeratePatterns の計算量爆発による DoS を防止する。

Closes #142

Generated with [Claude Code](https://claude.ai/code)