### PR TITLE
feat: add runtime schema validation for uploaded GOOD JSON files

### DIFF
--- a/webapp/src/components/FileUpload.tsx
+++ b/webapp/src/components/FileUpload.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from 'react'
 import type { GoodFile } from '@/lib/types'
 import { useTranslation } from '@/lib/i18n'
+import { validateGoodFile } from '@/lib/validateGoodFile'
 
 interface FileUploadProps {
   onLoad: (data: GoodFile) => void
@@ -25,11 +26,11 @@ export default function FileUpload({ onLoad }: FileUploadProps) {
     reader.onload = (e) => {
       try {
         const json = JSON.parse(e.target?.result as string)
-        if (json.format !== 'GOOD') {
+        if (!validateGoodFile(json)) {
           setError(t.upload.errorFormat)
           return
         }
-        onLoad(json as GoodFile)
+        onLoad(json)
       } catch {
         setError(t.upload.errorParse)
       }

--- a/webapp/src/lib/__tests__/FileUpload.test.tsx
+++ b/webapp/src/lib/__tests__/FileUpload.test.tsx
@@ -44,4 +44,79 @@ describe('FileUpload', () => {
     fireEvent.change(input, { target: { files: [oversizedFile] } })
     expect(onLoad).not.toHaveBeenCalled()
   })
+
+  it('artifacts が配列でない場合はエラーを表示してonLoadを呼ばない', async () => {
+    const onLoad = vi.fn()
+    renderFileUpload(onLoad)
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const badFile = makeFile(
+      'bad.json',
+      100,
+      JSON.stringify({ format: 'GOOD', artifacts: 'not-an-array' }),
+    )
+    fireEvent.change(input, { target: { files: [badFile] } })
+    await new Promise((r) => setTimeout(r, 0))
+    expect(screen.getByText('GOODフォーマットのJSONを選択してください')).toBeTruthy()
+    expect(onLoad).not.toHaveBeenCalled()
+  })
+
+  it('substat.value が NaN の場合はエラーを表示してonLoadを呼ばない', async () => {
+    const onLoad = vi.fn()
+    renderFileUpload(onLoad)
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const badFile = makeFile(
+      'bad.json',
+      100,
+      JSON.stringify({
+        format: 'GOOD',
+        artifacts: [
+          {
+            setKey: 'Thundersoother',
+            slotKey: 'goblet',
+            level: 20,
+            rarity: 5,
+            mainStatKey: 'def_',
+            location: '',
+            lock: false,
+            substats: [{ key: 'atk', value: null }],
+            totalRolls: 8,
+          },
+        ],
+      }),
+    )
+    fireEvent.change(input, { target: { files: [badFile] } })
+    await new Promise((r) => setTimeout(r, 0))
+    expect(screen.getByText('GOODフォーマットのJSONを選択してください')).toBeTruthy()
+    expect(onLoad).not.toHaveBeenCalled()
+  })
+
+  it('totalRolls が範囲外の場合はエラーを表示してonLoadを呼ばない', async () => {
+    const onLoad = vi.fn()
+    renderFileUpload(onLoad)
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const badFile = makeFile(
+      'bad.json',
+      100,
+      JSON.stringify({
+        format: 'GOOD',
+        artifacts: [
+          {
+            setKey: 'Thundersoother',
+            slotKey: 'goblet',
+            level: 20,
+            rarity: 5,
+            mainStatKey: 'def_',
+            location: '',
+            lock: false,
+            substats: [],
+            totalRolls: 999999,
+          },
+        ],
+      }),
+    )
+    fireEvent.change(input, { target: { files: [badFile] } })
+    await new Promise((r) => setTimeout(r, 0))
+    expect(screen.getByText('GOODフォーマットのJSONを選択してください')).toBeTruthy()
+    expect(onLoad).not.toHaveBeenCalled()
+  })
 })

--- a/webapp/src/lib/__tests__/validateGoodFile.test.ts
+++ b/webapp/src/lib/__tests__/validateGoodFile.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+import { validateGoodFile } from '../validateGoodFile'
+
+const validArtifact = {
+  setKey: 'Thundersoother',
+  slotKey: 'goblet',
+  level: 20,
+  rarity: 5,
+  mainStatKey: 'def_',
+  location: 'Xilonen',
+  lock: true,
+  substats: [
+    { key: 'atk', value: 18.0, initialValue: 18.0 },
+    { key: 'critRate_', value: 3.1, initialValue: 3.1 },
+  ],
+  totalRolls: 8,
+}
+
+const validGoodFile = {
+  format: 'GOOD',
+  version: 3,
+  source: 'Irminsul',
+  artifacts: [validArtifact],
+}
+
+describe('validateGoodFile', () => {
+  describe('正常系', () => {
+    it('有効な GOOD ファイルを受け入れる', () => {
+      expect(validateGoodFile(validGoodFile)).toBe(true)
+    })
+
+    it('artifacts が空配列でも受け入れる', () => {
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [] })).toBe(true)
+    })
+
+    it('artifacts フィールドがなくても受け入れる', () => {
+      expect(validateGoodFile({ format: 'GOOD', version: 1 })).toBe(true)
+    })
+
+    it('initialValue がないサブステータスも受け入れる', () => {
+      const artifact = {
+        ...validArtifact,
+        substats: [{ key: 'atk', value: 18.0 }],
+      }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(true)
+    })
+
+    it('substats が空配列の聖遺物も受け入れる', () => {
+      const artifact = { ...validArtifact, substats: [] }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(true)
+    })
+  })
+
+  describe('format チェック', () => {
+    it('null を拒否する', () => {
+      expect(validateGoodFile(null)).toBe(false)
+    })
+
+    it('配列を拒否する', () => {
+      expect(validateGoodFile([])).toBe(false)
+    })
+
+    it('文字列を拒否する', () => {
+      expect(validateGoodFile('GOOD')).toBe(false)
+    })
+
+    it('format が GOOD でない場合を拒否する', () => {
+      expect(validateGoodFile({ format: 'NOTGOOD' })).toBe(false)
+    })
+
+    it('format がない場合を拒否する', () => {
+      expect(validateGoodFile({ version: 3 })).toBe(false)
+    })
+  })
+
+  describe('artifacts チェック', () => {
+    it('artifacts が配列でない場合を拒否する', () => {
+      expect(validateGoodFile({ format: 'GOOD', artifacts: 'not-array' })).toBe(false)
+    })
+
+    it('artifacts がオブジェクトの場合を拒否する', () => {
+      expect(validateGoodFile({ format: 'GOOD', artifacts: {} })).toBe(false)
+    })
+
+    it('artifacts に null が含まれる場合を拒否する', () => {
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [null] })).toBe(false)
+    })
+  })
+
+  describe('substats チェック', () => {
+    it('substats が配列でない場合を拒否する', () => {
+      const artifact = { ...validArtifact, substats: 'bad' }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(false)
+    })
+
+    it('substat.value が NaN の場合を拒否する', () => {
+      const artifact = {
+        ...validArtifact,
+        substats: [{ key: 'atk', value: NaN }],
+      }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(false)
+    })
+
+    it('substat.value が Infinity の場合を拒否する', () => {
+      const artifact = {
+        ...validArtifact,
+        substats: [{ key: 'atk', value: Infinity }],
+      }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(false)
+    })
+
+    it('substat.value が負値の場合を拒否する', () => {
+      const artifact = {
+        ...validArtifact,
+        substats: [{ key: 'atk', value: -1 }],
+      }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(false)
+    })
+
+    it('substat.initialValue が NaN の場合を拒否する', () => {
+      const artifact = {
+        ...validArtifact,
+        substats: [{ key: 'atk', value: 18.0, initialValue: NaN }],
+      }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(false)
+    })
+
+    it('substat.initialValue が負値の場合を拒否する', () => {
+      const artifact = {
+        ...validArtifact,
+        substats: [{ key: 'atk', value: 18.0, initialValue: -5 }],
+      }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(false)
+    })
+  })
+
+  describe('totalRolls チェック（DoS 対策）', () => {
+    it('totalRolls が 0-12 の範囲外（巨大数）の場合を拒否する', () => {
+      const artifact = { ...validArtifact, totalRolls: 999999 }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(false)
+    })
+
+    it('totalRolls が負値の場合を拒否する', () => {
+      const artifact = { ...validArtifact, totalRolls: -1 }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(false)
+    })
+
+    it('totalRolls が Infinity の場合を拒否する', () => {
+      const artifact = { ...validArtifact, totalRolls: Infinity }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(false)
+    })
+
+    it('totalRolls が小数の場合を拒否する', () => {
+      const artifact = { ...validArtifact, totalRolls: 3.5 }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(false)
+    })
+
+    it('totalRolls が 12 の場合は受け入れる', () => {
+      const artifact = { ...validArtifact, totalRolls: 12 }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(true)
+    })
+
+    it('totalRolls が 0 の場合は受け入れる', () => {
+      const artifact = { ...validArtifact, totalRolls: 0 }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(true)
+    })
+  })
+})

--- a/webapp/src/lib/validateGoodFile.ts
+++ b/webapp/src/lib/validateGoodFile.ts
@@ -1,0 +1,59 @@
+import type { GoodFile } from './types'
+
+/**
+ * アップロードされた JSON が有効な GOOD フォーマットかを実行時に検証する。
+ * TypeScript の型キャストの代替として、実際の値を確認する。
+ */
+export function validateGoodFile(json: unknown): json is GoodFile {
+  if (typeof json !== 'object' || json === null || Array.isArray(json)) return false
+  const obj = json as Record<string, unknown>
+
+  if (obj.format !== 'GOOD') return false
+
+  // artifacts は省略可能だが、存在する場合は配列であること
+  if ('artifacts' in obj) {
+    if (!Array.isArray(obj.artifacts)) return false
+    for (const artifact of obj.artifacts) {
+      if (!isValidArtifact(artifact)) return false
+    }
+  }
+
+  return true
+}
+
+function isValidArtifact(artifact: unknown): boolean {
+  if (typeof artifact !== 'object' || artifact === null || Array.isArray(artifact)) return false
+  const obj = artifact as Record<string, unknown>
+
+  // substats は配列であること
+  if (!Array.isArray(obj.substats)) return false
+  for (const substat of obj.substats) {
+    if (!isValidSubstat(substat)) return false
+  }
+
+  // totalRolls が存在する場合は 0-12 の有限整数であること（DoS 対策）
+  if ('totalRolls' in obj) {
+    const r = obj.totalRolls
+    if (typeof r !== 'number' || !isFinite(r) || r < 0 || r > 12 || !Number.isInteger(r)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function isValidSubstat(substat: unknown): boolean {
+  if (typeof substat !== 'object' || substat === null || Array.isArray(substat)) return false
+  const obj = substat as Record<string, unknown>
+
+  // value は有限の非負数であること
+  if (typeof obj.value !== 'number' || !isFinite(obj.value) || obj.value < 0) return false
+
+  // initialValue が存在する場合も同様に検証
+  if ('initialValue' in obj) {
+    const iv = obj.initialValue
+    if (typeof iv !== 'number' || !isFinite(iv) || iv < 0) return false
+  }
+
+  return true
+}


### PR DESCRIPTION
GOOD形式JSONアップロード時の実行時スキーマ検証を追加します。`json as GoodFile`型キャストを実際のランタイム検証に置き換えます。

Closes #141

Generated with [Claude Code](https://claude.ai/code)