### PR TITLE
chore: add webapp/out/ to .claudeignore

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -9,6 +9,7 @@
 **/dist/
 **/build/
 **/.next/
+webapp/out/
 
 # ログ・キャッシュ
 **/*.log


### PR DESCRIPTION
.claudeignore に webapp/out/ を追加し、Next.js の静的エクスポートで生成されるビルド成果物を Claude の参照対象から除外する。

Close #158

Generated with [Claude Code](https://claude.ai/code)