### PR TITLE
fix: add mainStatKey filter to calcScore in reconstruction.ts

### DIFF
--- a/webapp/src/lib/reconstruction.ts
+++ b/webapp/src/lib/reconstruction.ts
@@ -19,6 +19,12 @@ const GUARANTEE_THRESHOLDS: Record<ReconstructionType, number> = {
   absolute: 4,
 }
 
+/**
+ * scoring.ts の TYPED_MAIN_STATS と同じ定義。
+ * このセットに含まれるメインステはスコアタイプとの一致チェックを行う。
+ */
+const TYPED_MAIN_STATS = new Set<string>(['hp_', 'atk_', 'def_', 'eleMas', 'enerRech_'])
+
 /** スコア種別ごとの追加ステ: [StatKey, 係数] */
 const SCORE_EXTRA: [ScoreTypeName, StatKey, number][] = [
   ['HP型', 'hp_', 1.0],
@@ -131,7 +137,11 @@ export function getGuaranteedIndices(
 }
 
 /** サブステ値マップから指定スコアタイプのスコアを計算 */
-function calcScore(subMap: Partial<Record<StatKey, number>>, scoreType: ScoreTypeName): number {
+function calcScore(
+  subMap: Partial<Record<StatKey, number>>,
+  mainStatKey: string,
+  scoreType: ScoreTypeName,
+): number {
   const cv = (subMap['critRate_'] ?? 0) * 2 + (subMap['critDMG_'] ?? 0)
 
   if (scoreType === 'CV') return cv
@@ -139,6 +149,8 @@ function calcScore(subMap: Partial<Record<StatKey, number>>, scoreType: ScoreTyp
   if (scoreType === '最良型') {
     let best = cv
     for (const [, key, coeff] of SCORE_EXTRA) {
+      // mainStatKey が型付きステで、かつこのタイプと不一致ならスコアは 0
+      if (TYPED_MAIN_STATS.has(mainStatKey) && mainStatKey !== key) continue
       const s = cv + (subMap[key] ?? 0) * coeff
       if (s > best) best = s
     }
@@ -147,6 +159,8 @@ function calcScore(subMap: Partial<Record<StatKey, number>>, scoreType: ScoreTyp
 
   const extra = SCORE_EXTRA.find(([name]) => name === scoreType)
   if (!extra) return cv
+  // scoring.ts の typeScore と同様: mainStatKey 不一致なら 0 を返す
+  if (TYPED_MAIN_STATS.has(mainStatKey) && mainStatKey !== extra[1]) return 0
   return cv + (subMap[extra[1]] ?? 0) * extra[2]
 }
 
@@ -187,7 +201,7 @@ export function calculateReconstructionRate(
     const idxB = substats.findIndex((s) => s.key === keyB)
     if (idxA === -1 || idxB === -1) continue
 
-    const rate = calcRateForPair(substats, rollCounts, enhTotal, scoreType, reconType, idxA, idxB)
+    const rate = calcRateForPair(substats, rollCounts, enhTotal, scoreType, reconType, idxA, idxB, artifact.mainStatKey)
     if (rate !== null && (bestRate === null || rate > bestRate)) {
       bestRate = rate
     }
@@ -204,13 +218,14 @@ function calcRateForPair(
   reconType: ReconstructionType,
   idxA: number,
   idxB: number,
+  mainStatKey: string,
 ): number | null {
   const threshold = GUARANTEE_THRESHOLDS[reconType]
 
   // 現在のスコア
   const currentSubMap: Partial<Record<StatKey, number>> = {}
   for (const s of substats) currentSubMap[s.key] = s.value
-  const currentScore = calcScore(currentSubMap, scoreType)
+  const currentScore = calcScore(currentSubMap, mainStatKey, scoreType)
 
   // 初期ロール値を推定: 現在値 - 平均強化幅 × 強化ロール数（負にならないようクリッピング）
   const initialValues = substats.map((s, i) =>
@@ -233,7 +248,7 @@ function calcRateForPair(
     for (let i = 0; i < substats.length; i++) {
       newSubMap[substats[i].key] = initialValues[i] + AVG_INCREMENT[substats[i].key] * pattern[i]
     }
-    if (calcScore(newSubMap, scoreType) > currentScore) {
+    if (calcScore(newSubMap, mainStatKey, scoreType) > currentScore) {
       successProb += prob
     }
   }


### PR DESCRIPTION
Issue #149 の修正。

`reconstruction.ts` の `calcScore` に `mainStatKey` フィルタを追加し、メインステとスコアタイプが不一致の場合にオッズが 0% と表示されるよう修正。

Closes #147

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/kotenbu135/mogumogu-paimon/actions/runs/22787428474