### PR TITLE
refactor: TYPED_MAIN_STATS の重複定義を共通化（DRY 違反）

### DIFF
--- a/webapp/src/lib/constants.ts
+++ b/webapp/src/lib/constants.ts
@@ -201,6 +201,12 @@ export function groupSetOptions(
   return groups
 }
 
+/**
+ * スコアタイプに対応したメインステキーのセット。
+ * メインステがこのセットに含まれる場合、対応しない型のスコアを 0 にする。
+ */
+export const TYPED_MAIN_STATS = new Set<string>(['hp_', 'atk_', 'def_', 'eleMas', 'enerRech_'])
+
 /** パーセント表記のサブステ */
 export const PERCENT_STATS = new Set<StatKey>([
   'hp_',

--- a/webapp/src/lib/reconstruction.ts
+++ b/webapp/src/lib/reconstruction.ts
@@ -11,6 +11,7 @@
 
 import type { Artifact, ReconstructionType, ScoreTypeName, StatKey } from './types'
 import { AVG_INCREMENT } from './scoring'
+import { TYPED_MAIN_STATS } from './constants'
 
 /** 再構築種別ごとの保証閾値（選択2サブステへの合計ロール数） */
 const GUARANTEE_THRESHOLDS: Record<ReconstructionType, number> = {
@@ -129,12 +130,6 @@ export function getGuaranteedIndices(
   }
   return null
 }
-
-/**
- * スコアタイプに対応したメインステキーのセット（scoring.ts と同定義）。
- * メインステがこのセットに含まれる場合、対応しない型のスコアを 0 にする。
- */
-const TYPED_MAIN_STATS = new Set<string>(['hp_', 'atk_', 'def_', 'eleMas', 'enerRech_'])
 
 /** サブステ値マップから指定スコアタイプのスコアを計算 */
 function calcScore(

--- a/webapp/src/lib/scoring.ts
+++ b/webapp/src/lib/scoring.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Artifact, ScoreResult, ScoreTypeName, StatKey } from './types'
-import { PERCENT_STATS } from './constants'
+import { PERCENT_STATS, TYPED_MAIN_STATS } from './constants'
 
 // サブステの4段階ティア値（低/中/高/最高）
 const SUBSTAT_TIERS: Record<StatKey, number[]> = {
@@ -176,12 +176,6 @@ export function estimateRollCounts(artifact: Artifact): number[] {
   }
   return floorRolls
 }
-
-/**
- * スコアタイプに対応したメインステキーのセット。
- * メインステがこのセットに含まれる場合、対応しない型のスコアを 0 にする。
- */
-const TYPED_MAIN_STATS = new Set<string>(['hp_', 'atk_', 'def_', 'eleMas', 'enerRech_'])
 
 /**
  * メインステとスコアタイプが一致しているか確認し、不一致ならスコアを 0 にする。


### PR DESCRIPTION
closes #174

## 変更内容

`TYPED_MAIN_STATS` を `scoring.ts` と `reconstruction.ts` の両方で定義していたものを `constants.ts` に移動してエクスポート。両モジュールから import する形に統一。

Generated with [Claude Code](https://claude.ai/code)") | [View branch](https://github.com/kotenbu135/mogumogu-paimon/tree/claude/issue-174-20260307-0747