### PR TITLE
fix: add physical_dmg_ to MAIN_STAT_ORDER

### DIFF
--- a/webapp/src/app/page.tsx
+++ b/webapp/src/app/page.tsx
@@ -13,7 +13,7 @@ const MAIN_STAT_ORDER: string[] = [
   'critRate_', 'critDMG_', 'atk_', 'hp_', 'def_',
   'eleMas', 'enerRech_', 'heal_',
   'anemo_dmg_', 'geo_dmg_', 'electro_dmg_', 'dendro_dmg_',
-  'hydro_dmg_', 'pyro_dmg_', 'cryo_dmg_',
+  'hydro_dmg_', 'pyro_dmg_', 'cryo_dmg_', 'physical_dmg_',
   'atk', 'hp', 'def',
 ]
 


### PR DESCRIPTION
Issue #175 の修正。

`physical_dmg_` が `MAIN_STAT_ORDER` から漏れていたため、物理ダメージバフの杯をアップロードしてもメインステフィルタに選択肢が表示されないバグを修正しました。

Closes #175

Generated with [Claude Code](https://claude.ai/code)