### PR TITLE
refactor: DRY違反解消 - NAV_LABEL_KEYSを廃止しSIDEBAR_ITEMSにlabelKeyを持たせる

### DIFF
--- a/webapp/src/components/Sidebar.tsx
+++ b/webapp/src/components/Sidebar.tsx
@@ -5,16 +5,6 @@ import { usePathname } from 'next/navigation'
 import { SIDEBAR_ITEMS } from '@/lib/sidebarItems'
 import { useTranslation } from '@/lib/i18n'
 
-/** SIDEBAR_ITEMS の href → 翻訳キーのマッピング */
-const NAV_LABEL_KEYS: Record<string, keyof ReturnType<typeof useTranslation>['t']['nav']> = {
-  '/': 'home',
-  '/about-score': 'aboutScore',
-  '/about-reconstruction': 'aboutReconstruction',
-  '/how-to-use': 'howToUse',
-  '/faq': 'faq',
-  '/disclaimer': 'disclaimer',
-}
-
 export default function Sidebar() {
   const pathname = usePathname()
   const { t, lang, setLang } = useTranslation()
@@ -24,8 +14,7 @@ export default function Sidebar() {
       <ul className="sidebar-list">
         {SIDEBAR_ITEMS.map((item) => {
           const isActive = pathname === item.href
-          const labelKey = NAV_LABEL_KEYS[item.href]
-          const label = labelKey ? t.nav[labelKey] : item.label
+          const label = t.nav[item.labelKey]
           return (
             <li key={item.href}>
               <Link

--- a/webapp/src/lib/__tests__/sidebarItems.test.ts
+++ b/webapp/src/lib/__tests__/sidebarItems.test.ts
@@ -7,38 +7,38 @@ describe('SIDEBAR_ITEMS', () => {
   })
 
   it('ホームが最初の項目である', () => {
-    expect(SIDEBAR_ITEMS[0].label).toBe('ホーム')
+    expect(SIDEBAR_ITEMS[0].labelKey).toBe('home')
     expect(SIDEBAR_ITEMS[0].href).toBe('/')
   })
 
   it('スコアについてが2番目の項目である', () => {
-    expect(SIDEBAR_ITEMS[1].label).toBe('スコアについて')
+    expect(SIDEBAR_ITEMS[1].labelKey).toBe('aboutScore')
     expect(SIDEBAR_ITEMS[1].href).toBe('/about-score')
   })
 
   it('再構築についてが3番目の項目である', () => {
-    expect(SIDEBAR_ITEMS[2].label).toBe('再構築について')
+    expect(SIDEBAR_ITEMS[2].labelKey).toBe('aboutReconstruction')
     expect(SIDEBAR_ITEMS[2].href).toBe('/about-reconstruction')
   })
 
   it('使い方が4番目の項目である', () => {
-    expect(SIDEBAR_ITEMS[3].label).toBe('使い方')
+    expect(SIDEBAR_ITEMS[3].labelKey).toBe('howToUse')
     expect(SIDEBAR_ITEMS[3].href).toBe('/how-to-use')
   })
 
   it('よくある質問が5番目の項目である', () => {
-    expect(SIDEBAR_ITEMS[4].label).toBe('よくある質問')
+    expect(SIDEBAR_ITEMS[4].labelKey).toBe('faq')
     expect(SIDEBAR_ITEMS[4].href).toBe('/faq')
   })
 
   it('免責事項が最後の項目である', () => {
-    expect(SIDEBAR_ITEMS[5].label).toBe('免責事項')
+    expect(SIDEBAR_ITEMS[5].labelKey).toBe('disclaimer')
     expect(SIDEBAR_ITEMS[5].href).toBe('/disclaimer')
   })
 
-  it('各項目にlabelとhrefが存在する', () => {
+  it('各項目にlabelKeyとhrefが存在する', () => {
     for (const item of SIDEBAR_ITEMS) {
-      expect(item.label).toBeTruthy()
+      expect(item.labelKey).toBeTruthy()
       expect(item.href).toBeTruthy()
     }
   })

--- a/webapp/src/lib/sidebarItems.ts
+++ b/webapp/src/lib/sidebarItems.ts
@@ -1,13 +1,17 @@
+import type { Translations } from './i18n/types'
+
+export type NavLabelKey = keyof Translations['nav']
+
 export interface SidebarItem {
-  label: string
+  labelKey: NavLabelKey
   href: string
 }
 
 export const SIDEBAR_ITEMS: SidebarItem[] = [
-  { label: 'ホーム', href: '/' },
-  { label: 'スコアについて', href: '/about-score' },
-  { label: '再構築について', href: '/about-reconstruction' },
-  { label: '使い方', href: '/how-to-use' },
-  { label: 'よくある質問', href: '/faq' },
-  { label: '免責事項', href: '/disclaimer' },
+  { labelKey: 'home', href: '/' },
+  { labelKey: 'aboutScore', href: '/about-score' },
+  { labelKey: 'aboutReconstruction', href: '/about-reconstruction' },
+  { labelKey: 'howToUse', href: '/how-to-use' },
+  { labelKey: 'faq', href: '/faq' },
+  { labelKey: 'disclaimer', href: '/disclaimer' },
 ]


### PR DESCRIPTION
Fixes #182

## 変更内容

ナビゲーション定義が3ファイルに分散していたDRY違反を解消。

- `sidebarItems.ts`: `label` フィールドを `labelKey: NavLabelKey` に置き換え
- `Sidebar.tsx`: `NAV_LABEL_KEYS` マッピングを完全削除
- `sidebarItems.test.ts`: `labelKey` に合わせてテストを更新

Generated with [Claude Code](https://claude.ai/code)