### PR TITLE
refactor: remove dead SCORE_TYPE_FORMULAS constant (DRY fix)

### DIFF
--- a/webapp/src/lib/__tests__/scoringFormulas.test.ts
+++ b/webapp/src/lib/__tests__/scoringFormulas.test.ts
@@ -1,57 +1,58 @@
 /**
  * スコアタイプ計算式定数のテスト
- * - SCORE_TYPE_FORMULAS: 各スコアタイプの表示ラベルと計算式を保持
+ * - ja.scoreFormulas: 各スコアタイプの表示ラベルと計算式を保持
  */
 
 import { describe, it, expect } from 'vitest'
-import { SCORE_TYPE_FORMULAS } from '@/lib/constants'
+import { ja } from '@/lib/i18n/ja'
 
+const scoreFormulas = ja.scoreFormulas
 const EXPECTED_SCORE_TYPES = ['CV', 'HP型', '攻撃型', '防御型', '熟知型', 'チャージ型', '最良型'] as const
 
-describe('SCORE_TYPE_FORMULAS', () => {
+describe('scoreFormulas', () => {
   it('全スコアタイプのエントリが存在する', () => {
     for (const type of EXPECTED_SCORE_TYPES) {
-      expect(SCORE_TYPE_FORMULAS[type]).toBeDefined()
+      expect(scoreFormulas[type]).toBeDefined()
     }
   })
 
   it('各エントリに label と formula が含まれる', () => {
     for (const type of EXPECTED_SCORE_TYPES) {
-      const entry = SCORE_TYPE_FORMULAS[type]
+      const entry = scoreFormulas[type]
       expect(entry.label).toBeTruthy()
       expect(entry.formula).toBeTruthy()
     }
   })
 
   it('CVスコアの計算式に会心率と会心ダメージが含まれる', () => {
-    const formula = SCORE_TYPE_FORMULAS['CV'].formula
+    const formula = scoreFormulas['CV'].formula
     expect(formula).toContain('会心率')
     expect(formula).toContain('会心ダメージ')
   })
 
   it('HP型の計算式にHP%が含まれる', () => {
-    expect(SCORE_TYPE_FORMULAS['HP型'].formula).toContain('HP%')
+    expect(scoreFormulas['HP型'].formula).toContain('HP%')
   })
 
   it('攻撃型の計算式に攻撃力%が含まれる', () => {
-    expect(SCORE_TYPE_FORMULAS['攻撃型'].formula).toContain('攻撃力%')
+    expect(scoreFormulas['攻撃型'].formula).toContain('攻撃力%')
   })
 
   it('防御型の計算式に防御力%が含まれる', () => {
-    expect(SCORE_TYPE_FORMULAS['防御型'].formula).toContain('防御力%')
+    expect(scoreFormulas['防御型'].formula).toContain('防御力%')
   })
 
   it('熟知型の計算式に元素熟知が含まれる', () => {
-    expect(SCORE_TYPE_FORMULAS['熟知型'].formula).toContain('元素熟知')
+    expect(scoreFormulas['熟知型'].formula).toContain('元素熟知')
   })
 
   it('チャージ型の計算式に元素チャージが含まれる', () => {
-    expect(SCORE_TYPE_FORMULAS['チャージ型'].formula).toContain('元素チャージ')
+    expect(scoreFormulas['チャージ型'].formula).toContain('元素チャージ')
   })
 
   it('最良型のエントリが存在する', () => {
-    expect(SCORE_TYPE_FORMULAS['最良型']).toBeDefined()
-    expect(SCORE_TYPE_FORMULAS['最良型'].label).toBeTruthy()
-    expect(SCORE_TYPE_FORMULAS['最良型'].formula).toBeTruthy()
+    expect(scoreFormulas['最良型']).toBeDefined()
+    expect(scoreFormulas['最良型'].label).toBeTruthy()
+    expect(scoreFormulas['最良型'].formula).toBeTruthy()
   })
 })

--- a/webapp/src/lib/constants.ts
+++ b/webapp/src/lib/constants.ts
@@ -13,17 +13,6 @@ export const ALL_SUBSTAT_KEYS: StatKey[] = [
   'eleMas', 'enerRech_', 'atk', 'hp', 'def',
 ]
 
-/** 各スコアタイプの表示ラベルと計算式 */
-export const SCORE_TYPE_FORMULAS: Record<ScoreTypeName, { label: string; formula: string }> = {
-  CV: { label: 'CVスコア', formula: '会心率×2 + 会心ダメージ' },
-  HP型: { label: 'HP型', formula: 'CV + HP%×1.0' },
-  攻撃型: { label: '攻撃型', formula: 'CV + 攻撃力%×1.0' },
-  防御型: { label: '防御型', formula: 'CV + 防御力%×0.8' },
-  熟知型: { label: '熟知型', formula: 'CV + 元素熟知×0.25' },
-  チャージ型: { label: 'チャージ型', formula: 'CV + 元素チャージ×0.9' },
-  最良型: { label: '最良型', formula: '全タイプのうち最高値' },
-}
-
 export const ARTIFACT_SET_NAMES: Record<string, string> = {
   ADayCarvedFromRisingWinds: '風立ちの日',
   Adventurer: '冒険者',


### PR DESCRIPTION
SCORE_TYPE_FORMULAS (constants.ts) を削除し、テストを ja.scoreFormulas に切り替えました。

Closes #181

Generated with [Claude Code](https://claude.ai/code)