### PR TITLE
refactor: extract getAllStatNames helper to eliminate DRY violation

### DIFF
--- a/webapp/src/app/page.tsx
+++ b/webapp/src/app/page.tsx
@@ -7,6 +7,7 @@ import ControlsBar from '@/components/ControlsBar'
 import type { GoodFile, RankedArtifact, ReconstructionType, ScoreTypeName, StatKey } from '@/lib/types'
 import { groupSetOptions, SCORE_TYPE_OPTIONS, ALL_SUBSTAT_KEYS } from '@/lib/constants'
 import { useTranslation } from '@/lib/i18n'
+import { getAllStatNames } from '@/lib/i18n/types'
 import { useArtifactFilters } from '@/hooks/useArtifactFilters'
 
 const MAIN_STAT_ORDER: string[] = [
@@ -125,7 +126,7 @@ export default function HomePage() {
       })
   }, [allRanked, filters.filterSets, filters.filterSlot, filters.filterMainStat, filters.filterSubStats, filters.filterInitialOp, subStatSort, scoreType, reconRates, reconSort])
 
-  const allMainStatNames: Record<string, string> = { ...t.stats, ...t.mainStatExtra }
+  const allMainStatNames = getAllStatNames(t)
 
   return (
     <main className="main-container">

--- a/webapp/src/components/ArtifactCard.tsx
+++ b/webapp/src/components/ArtifactCard.tsx
@@ -7,6 +7,7 @@ import { decomposeRolls, getEffectiveStats } from '@/lib/scoring'
 import { getContextMenuItems, getCharContextMenuItems } from '@/lib/contextMenu'
 import ContextMenu from './ContextMenu'
 import { useTranslation } from '@/lib/i18n'
+import { getAllStatNames } from '@/lib/i18n/types'
 
 interface ArtifactCardProps {
   rank: number
@@ -69,7 +70,7 @@ export default function ArtifactCard({ rank, entry, scoreType, reconRate, onFilt
   const { setKey, slotKey, level, rarity, location, substats, mainStatKey } = artifact
   const { t } = useTranslation()
 
-  const allStatLabels: Record<string, string> = { ...t.stats, ...t.mainStatExtra }
+  const allStatLabels = getAllStatNames(t)
   const setName = t.artifactSetNames[setKey] ?? ARTIFACT_SET_NAMES[setKey] ?? setKey
   const slotName = t.slots[slotKey] ?? SLOT_NAMES[slotKey] ?? slotKey
   const mainStatName = allStatLabels[mainStatKey] ?? MAIN_STAT_NAMES[mainStatKey] ?? mainStatKey

--- a/webapp/src/lib/i18n/types.ts
+++ b/webapp/src/lib/i18n/types.ts
@@ -155,3 +155,8 @@ export interface DisclaimerT {
   responsibility: { heading: string; p1: string; p2: string; p3: string }
   disclaimer: { heading: string; p1: string }
 }
+
+/** stats と mainStatExtra をマージした全ステータス名マップを返す */
+export function getAllStatNames(t: Translations): Record<string, string> {
+  return { ...t.stats, ...t.mainStatExtra }
+}


### PR DESCRIPTION
DRY違反を解消するため、`getAllStatNames`ヘルパーを`i18n/types.ts`に追加し、`page.tsx`と`ArtifactCard.tsx`の重複パターンを置き換えました。

Closes #180

Generated with [Claude Code](https://claude.ai/code)