### PR TITLE
fix: remove invalid X-Frame-Options meta tag

### DIFF
--- a/webapp/src/app/layout.tsx
+++ b/webapp/src/app/layout.tsx
@@ -17,8 +17,7 @@ export default function RootLayout({
     <html lang="ja">
       <head>
         <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
-        <meta httpEquiv="X-Frame-Options" content="DENY" />
-        <meta name="referrer" content="no-referrer" />
+<meta name="referrer" content="no-referrer" />
       </head>
       <body>
         <LanguageProvider>


### PR DESCRIPTION
X-Frame-Options はmeta タグでは機能せず、HTTP ヘッダーでのみ有効です。

fixes #184

Generated with [Claude Code](https://claude.ai/code)