### PR TITLE
fix: remove unsafe-inline from script-src in CSP

### DIFF
--- a/webapp/src/app/layout.tsx
+++ b/webapp/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <head>
-        <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
+        <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
 <meta name="referrer" content="no-referrer" />
       </head>
       <body>


### PR DESCRIPTION
closes #199

Content Security Policy の script-src から 'unsafe-inline' を除去し、任意のインラインスクリプト実行を防ぐ。Code scanning alert #3 を解決する。

Generated with [Claude Code](https://claude.ai/code)