### PR TITLE
Potential fix for code scanning alert no. 2: Code injection

### DIFF
--- a/.github/workflows/ci-failure-notify.yml
+++ b/.github/workflows/ci-failure-notify.yml
@@ -15,8 +15,9 @@ jobs:
     steps:
       - name: ブランチ名からIssue番号を抽出
         id: get-issue
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          BRANCH="${{ github.event.workflow_run.head_branch }}"
           # ブランチ命名規則: claude/issue-{番号}-* からIssue番号を取得
           if [[ "$BRANCH" =~ claude/issue-([0-9]+)- ]]; then
             echo "issue_number=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Potential fix for [https://github.com/kotenbu135/mogumogu-paimon/security/code-scanning/2](https://github.com/kotenbu135/mogumogu-paimon/security/code-scanning/2)

To fix the issue, we should stop interpolating `github.event.workflow_run.head_branch` directly into the shell script, and instead pass it via an environment variable configured in the step, then read it with normal shell variable expansion. This follows GitHub’s recommended mitigation: use `${{ ... }}` only in the `env:` block (or other workflow-level fields), and then consume `$VAR` within the script.

Concretely, in `.github/workflows/ci-failure-notify.yml`, in the step `ブランチ名からIssue番号を抽出`, we will:
- Add an `env:` section that sets `BRANCH` to `${{ github.event.workflow_run.head_branch }}`.
- Change the shell script so that it no longer embeds `${{ ... }}`; instead, it will just reference `$BRANCH`.
- The rest of the logic (regex match, echoing, writing to `$GITHUB_OUTPUT`) remains unchanged.

No other steps need modification, because the later JavaScript step already uses the value only for constructing a comment body; even if it is user-controlled, it is not executed as code there.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
