### PR TITLE
fix: CSPエラーを修正（script-src unsafe-inlineを追加）

### DIFF
--- a/webapp/src/app/layout.tsx
+++ b/webapp/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <head>
-        <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
+        <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
 <meta name="referrer" content="no-referrer" />
       </head>
       <body>


### PR DESCRIPTION
closes #206

Next.jsの静的エクスポートが生成するインラインスクリプトがCSPポリシーによりブロックされていました。script-srcに unsafe-inline を追加して修正します。

Generated with [Claude Code](https://claude.ai/code)