### PR TITLE
feat: add claude-code-action automation workflows

### DIFF
--- a/.github/workflows/claude-dependency-review.yml
+++ b/.github/workflows/claude-dependency-review.yml
@@ -1,0 +1,38 @@
+name: Claude Dependency Review
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  review:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Dependency Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          direct_prompt: |
+            この Dependabot PR の依存関係更新をレビューしてください。
+
+            以下の観点でチェックし、PR コメントとして報告してください:
+            - 更新されたパッケージのバージョン差分（メジャー / マイナー / パッチ）
+            - 破壊的変更（BREAKING CHANGES）の有無
+            - セキュリティ修正が含まれているか
+            - このプロジェクトへの影響（package.json と既存コードの互換性）
+
+            安全と判断した場合は「安全な更新です」とコメントしてください。
+            懸念がある場合は具体的なリスクと対応案を示してください。
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-doc-sync.yml
+++ b/.github/workflows/claude-doc-sync.yml
@@ -1,0 +1,41 @@
+name: Claude Doc Sync Check
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  doc-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Doc Sync Check
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          direct_prompt: |
+            この PR の変更が docs/spec/*.md の仕様書と整合しているかチェックしてください。
+
+            手順:
+            1. PR の差分を確認
+            2. 変更されたコードに関連する仕様書（docs/spec/*.md）を特定
+            3. 仕様書の記述と実装コードの整合性を確認
+
+            以下のケースを検出して PR コメントとして報告してください:
+            - 実装が変更されたが仕様書が更新されていない
+            - 仕様書に記載されている仕様が実装と一致しない
+            - 新しい機能が追加されたが仕様書に未記載
+
+            乖離がない場合は「仕様書と実装は整合しています」とコメントしてください。
+            乖離がある場合は具体的な箇所と修正提案を示してください。
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-issue-labeler.yml
+++ b/.github/workflows/claude-issue-labeler.yml
@@ -1,0 +1,42 @@
+name: Claude Issue Labeler
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Issue Labeler
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          direct_prompt: |
+            この Issue のタイトルと本文を解析して、適切なラベルを付与してください。
+
+            使用可能なラベル:
+            - bug: バグ報告
+            - enhancement: 機能追加・改善
+            - documentation: ドキュメント関連
+            - refactor: リファクタリング
+            - test: テスト関連
+            - ci: CI/CD 関連
+            - dependencies: 依存関係の更新
+
+            gh コマンドを使ってラベルを付与してください。
+            該当するラベルが存在しない場合は先に作成してから付与してください。
+          claude_args: >-
+            --allowedTools
+            "Bash(gh issue edit:*),Bash(gh label create:*),Bash(gh label list:*)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-pr-description.yml
+++ b/.github/workflows/claude-pr-description.yml
@@ -1,0 +1,46 @@
+name: Claude PR Description
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  describe:
+    # 既に説明文がある場合はスキップ
+    if: github.event.pull_request.body == '' || github.event.pull_request.body == null
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude PR Description Generator
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          direct_prompt: |
+            この PR の変更差分とコミット履歴を解析して、PR の説明文を生成してください。
+
+            以下のフォーマットで gh コマンドを使って PR の body を更新してください:
+
+            ## Summary
+            - 変更内容の要約（箇条書き）
+
+            ## Test plan
+            - テスト方法（箇条書き）
+
+            ## Related Issues
+            - 関連する Issue があればリンク
+
+            日本語で記述してください。
+          claude_args: >-
+            --allowedTools
+            "Bash(gh pr edit:*),Bash(git log:*),Bash(git diff:*)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,41 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  review:
+    # claude.yml のメンションベースレビューと重複しないよう自動レビュー専用
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          direct_prompt: |
+            この PR の差分をレビューしてください。
+            CLAUDE.md のルールに基づいて以下の観点でチェックし、PR コメントとして投稿してください:
+
+            - TypeScript の型安全性
+            - TDD 方針（新ロジックにテストがあるか）
+            - Conventional Commits 形式の遵守
+            - セキュリティ上の問題（OWASP Top 10）
+            - コードの品質・可読性
+
+            問題がなければ「LGTM」とだけコメントしてください。
+            問題がある場合は具体的な箇所と改善案を示してください。
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -1,0 +1,39 @@
+name: Claude Release Notes
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release-notes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Release Notes Generator
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          direct_prompt: |
+            main ブランチへの最新のプッシュに含まれるコミットを解析して、リリースノートを生成してください。
+
+            手順:
+            1. 直前のタグまたは前回のマージコミットからのコミット履歴を取得
+            2. Conventional Commits 形式に基づいてカテゴリ分け（feat / fix / refactor / docs / test / ci）
+            3. 変更内容を日本語で要約
+
+            gh release create コマンドで GitHub Release を作成してください。
+            タグ名は日付ベース（v0.YYYYMMDD.N 形式）で、既存タグと重複しないようにしてください。
+
+            リリースに含める変更がない（CI のみの変更など）場合は何もせず終了してください。
+          claude_args: >-
+            --allowedTools
+            "Bash(git log:*),Bash(git tag:*),Bash(git diff:*),Bash(gh release create:*),Bash(gh release list:*)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- PR 自動レビューワークフロー追加（`claude-pr-review.yml`） #212
- Issue 自動ラベリングワークフロー追加（`claude-issue-labeler.yml`） #213
- PR 説明文自動生成ワークフロー追加（`claude-pr-description.yml`） #214
- リリースノート・CHANGELOG 自動生成ワークフロー追加（`claude-release-notes.yml`） #215
- 依存関係更新 PR 自動レビューワークフロー追加（`claude-dependency-review.yml`） #216
- ドキュメント同期チェックワークフロー追加（`claude-doc-sync.yml`） #217

すべて `anthropics/claude-code-action@v1` を使用し、既存の `claude.yml` と同じ認証方式（`CLAUDE_CODE_OAUTH_TOKEN`）を採用。

## Test plan
- [ ] 各ワークフローの YAML 構文が正しいこと（CI で検証）
- [ ] PR を開いた際に `claude-pr-review` と `claude-doc-sync` がトリガーされること
- [ ] Issue を作成した際に `claude-issue-labeler` がトリガーされること
- [ ] 説明文が空の PR で `claude-pr-description` がトリガーされること
- [ ] main への push で `claude-release-notes` がトリガーされること
- [ ] Dependabot PR で `claude-dependency-review` がトリガーされること

Closes #212, closes #213, closes #214, closes #215, closes #216, closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)