### PR TITLE
fix: unify totalRolls upper limit to 12 and add image fallback

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -508,6 +508,11 @@ body {
   object-fit: contain;
 }
 
+.artifact-img-placeholder {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1.5rem;
+}
+
 .artifact-info {
   flex: 1;
   min-width: 0;

--- a/webapp/src/components/ArtifactCard.tsx
+++ b/webapp/src/components/ArtifactCard.tsx
@@ -134,7 +134,7 @@ export default function ArtifactCard({ rank, entry, scoreType, reconRate, onFilt
           onClick={handleImageClick}
           title={canFilter ? t.card.clickToFilter : undefined}
         >
-          {artifactImgSrc && (
+          {artifactImgSrc ? (
             <img
               src={artifactImgSrc}
               alt={`${setName} ${slotName}`}
@@ -143,6 +143,8 @@ export default function ArtifactCard({ rank, entry, scoreType, reconRate, onFilt
                 (e.target as HTMLImageElement).style.display = 'none'
               }}
             />
+          ) : (
+            <span className="artifact-img-placeholder" aria-hidden="true">?</span>
           )}
         </div>
 

--- a/webapp/src/lib/__tests__/reconstruction.test.ts
+++ b/webapp/src/lib/__tests__/reconstruction.test.ts
@@ -207,8 +207,8 @@ describe('calculateReconstructionRate', () => {
     expect(calculateReconstructionRate(artLv16, [2, 1, 1, 1], 'CV', 'normal')).toBeNull()
   })
 
-  it('totalRolls > 20 の場合は null を返す（DoS 防止）', () => {
-    const art = makeArtifact({ totalRolls: 21 })
+  it('totalRolls > 12 の場合は null を返す（DoS 防止・バリデーション上限と統一）', () => {
+    const art = makeArtifact({ totalRolls: 13 })
     expect(calculateReconstructionRate(art, [2, 1, 1, 1], 'CV', 'normal')).toBeNull()
 
     const artExcessive = makeArtifact({ totalRolls: 1000 })

--- a/webapp/src/lib/reconstruction.ts
+++ b/webapp/src/lib/reconstruction.ts
@@ -175,8 +175,8 @@ export function calculateReconstructionRate(
   // ★5 Lv.20 以外は対象外
   if (artifact.rarity !== 5 || artifact.level !== 20) return null
 
-  // totalRolls 上限チェック（DoS 防止: enumeratePatterns の計算量爆発を防ぐ）
-  if (artifact.totalRolls > 20) return null
+  // totalRolls 上限チェック（DoS 防止: バリデーション上限と統一）
+  if (artifact.totalRolls > 12) return null
 
   const { substats } = artifact
   if (substats.length !== 4) return null


### PR DESCRIPTION
closes #230

## 変更内容

- `reconstruction.ts`: DoS 防止閾値を 20 から 12 に変更（`validateGoodFile.ts` のバリデーション上限と統一）
- `ArtifactCard.tsx`: 画像パスが不正な場合に `?` プレースホルダーを表示
- `globals.css`: `.artifact-img-placeholder` スタイルを追加

Generated with [Claude Code](https://claude.ai/code)