### PR TITLE
test: add edge case and i18n coverage tests (#233)

### DIFF
--- a/webapp/src/lib/__tests__/estimateRollCounts.test.ts
+++ b/webapp/src/lib/__tests__/estimateRollCounts.test.ts
@@ -236,4 +236,26 @@ describe('estimateRollCounts - 境界系', () => {
       expect(Number.isInteger(r)).toBe(true)
     }
   })
+
+  it('フォールバック時に remainder > substats.length の場合、Math.min で上限を守る', () => {
+    // critRate_=2.7 と critDMG_=5.4 は共に raw≈0 → floorRolls=[0,0]
+    // upgradeTarget = 7-2 = 5, remainder=5 > frac.length=2
+    // Math.min(5,2)=2 → 各サブステに1ずつ加算 → [1,1]
+    const artifact = makeArtifact({
+      substats: [
+        { key: 'critRate_', value: 2.7 },
+        { key: 'critDMG_', value: 5.4 },
+      ],
+      totalRolls: 7,
+    })
+
+    const result = estimateRollCounts(artifact)
+
+    expect(result).toHaveLength(2)
+    expect(result).toEqual([1, 1])
+    for (const r of result) {
+      expect(r).toBeGreaterThanOrEqual(0)
+      expect(Number.isInteger(r)).toBe(true)
+    }
+  })
 })

--- a/webapp/src/lib/__tests__/i18n.test.ts
+++ b/webapp/src/lib/__tests__/i18n.test.ts
@@ -1,0 +1,138 @@
+/**
+ * i18n 翻訳キー一致テスト
+ *
+ * 英語（en）と日本語（ja）翻訳の構造一致・値の完全性を検証する。
+ * TypeScript の型チェックに加え、実行時に全キーが存在し空文字でないことを確認する。
+ */
+
+import { describe, it, expect } from 'vitest'
+import { ja } from '@/lib/i18n/ja'
+import { en } from '@/lib/i18n/en'
+
+/**
+ * オブジェクトのリーフキーを再帰的に収集する。
+ * 配列は各要素のキーではなく "配列インデックス" として扱う。
+ * @param skipKeys - 収集をスキップするトップレベルキー名
+ */
+function collectLeafPaths(obj: unknown, prefix = '', skipKeys: string[] = []): string[] {
+  if (obj === null || typeof obj !== 'object') return [prefix]
+  if (Array.isArray(obj)) {
+    // 配列は長さと各要素の型のみ確認するため、代表パスとして記録
+    return [prefix + '[]']
+  }
+  const paths: string[] = []
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    const path = prefix ? `${prefix}.${key}` : key
+    // スキップ対象キーは除外
+    if (skipKeys.some((sk) => path === sk || path.startsWith(sk + '.'))) continue
+    paths.push(...collectLeafPaths(value, path, skipKeys))
+  }
+  return paths
+}
+
+/**
+ * オブジェクト内のすべての文字列値を再帰的に収集する（パスつき）。
+ * 配列要素も含む。
+ * @param skipPaths - 収集をスキップするパスのプレフィックス
+ */
+function collectStringEntries(
+  obj: unknown,
+  prefix = '',
+  skipPaths: string[] = [],
+): { path: string; value: string }[] {
+  if (typeof obj === 'string') return [{ path: prefix, value: obj }]
+  if (obj === null || typeof obj !== 'object') return []
+  if (Array.isArray(obj)) {
+    return obj.flatMap((v, i) =>
+      collectStringEntries(v, `${prefix}[${i}]`, skipPaths)
+    )
+  }
+  return Object.entries(obj as Record<string, unknown>).flatMap(([key, value]) => {
+    const path = prefix ? `${prefix}.${key}` : key
+    if (skipPaths.some((sp) => path === sp || path.startsWith(sp + '.'))) return []
+    return collectStringEntries(value, path, skipPaths)
+  })
+}
+
+describe('i18n - 翻訳の構造一致', () => {
+  it('en と ja のリーフキーが一致する（意図的スパースフィールドを除く）', () => {
+    // artifactSetNames は「上書き用スパースマップ」のため ja は空が正常
+    const skipKeys = ['lang', 'artifactSetNames']
+    const jaPaths = collectLeafPaths(ja, '', skipKeys)
+    const enPaths = collectLeafPaths(en, '', skipKeys)
+
+    const missingInEn = jaPaths.filter((p) => !enPaths.includes(p))
+    const missingInJa = enPaths.filter((p) => !jaPaths.includes(p))
+
+    expect(missingInEn).toEqual([])
+    expect(missingInJa).toEqual([])
+  })
+
+  it('en と ja の最上位キーが一致する', () => {
+    const jaKeys = Object.keys(ja).sort()
+    const enKeys = Object.keys(en).sort()
+    expect(jaKeys).toEqual(enKeys)
+  })
+})
+
+describe('i18n - 値の完全性', () => {
+  it('ja の文字列値が空文字でない（言語構造上の意図的空文字を除く）', () => {
+    // p1pre / p1post は日本語では文の前後が不要なため空文字が正常
+    const skipPaths = ['pages.howToUse.step1.p1pre', 'pages.howToUse.step1.p1post']
+    const entries = collectStringEntries(ja, '', skipPaths)
+    const empty = entries.filter((e) => e.value.trim() === '')
+    expect(empty.map((e) => e.path)).toEqual([])
+  })
+
+  it('en の全文字列値が空文字でない', () => {
+    const entries = collectStringEntries(en)
+    const empty = entries.filter((e) => e.value.trim() === '')
+    expect(empty.map((e) => e.path)).toEqual([])
+  })
+})
+
+describe('i18n - 言語設定', () => {
+  it('ja.lang が "ja" である', () => {
+    expect(ja.lang).toBe('ja')
+  })
+
+  it('en.lang が "en" である', () => {
+    expect(en.lang).toBe('en')
+  })
+})
+
+describe('i18n - nav キーの一致', () => {
+  it('nav の全キーが en と ja で一致する', () => {
+    expect(Object.keys(en.nav).sort()).toEqual(Object.keys(ja.nav).sort())
+  })
+})
+
+describe('i18n - stats キーの一致', () => {
+  it('stats の全キーが en と ja で一致する', () => {
+    expect(Object.keys(en.stats).sort()).toEqual(Object.keys(ja.stats).sort())
+  })
+})
+
+describe('i18n - scoreFormulas キーの一致', () => {
+  it('scoreFormulas の全スコアタイプキーが en と ja で一致する', () => {
+    expect(Object.keys(en.scoreFormulas).sort()).toEqual(Object.keys(ja.scoreFormulas).sort())
+  })
+
+  it('scoreFormulas の各エントリが label と formula を持つ', () => {
+    for (const [key, entry] of Object.entries(en.scoreFormulas)) {
+      expect(entry).toHaveProperty('label')
+      expect(entry).toHaveProperty('formula')
+      expect(entry.label.trim()).not.toBe('')
+      expect(entry.formula.trim()).not.toBe('')
+      const jaEntry = ja.scoreFormulas[key as keyof typeof ja.scoreFormulas]
+      expect(jaEntry).toHaveProperty('label')
+      expect(jaEntry).toHaveProperty('formula')
+    }
+  })
+})
+
+describe('i18n - reconTypes キーの一致', () => {
+  it('reconTypes の全キーが en と ja で一致する', () => {
+    expect(Object.keys(en.reconTypes).sort()).toEqual(Object.keys(ja.reconTypes).sort())
+  })
+})

--- a/webapp/src/lib/__tests__/reconstruction.test.ts
+++ b/webapp/src/lib/__tests__/reconstruction.test.ts
@@ -375,6 +375,22 @@ describe('calculateReconstructionRate', () => {
     expect(rate!).toBeLessThanOrEqual(100)
   })
 
+  it('絶対再構築で enhTotal が少ない場合は null を返す（totalFilteredProb === 0）', () => {
+    // enhTotal=1 で absolute（閾値=4）の場合、どのパターンも idxA+idxB >= 4 を満たさない
+    const art = makeArtifact({
+      substats: [
+        { key: 'critRate_', value: 3.9 },
+        { key: 'critDMG_', value: 7.8 },
+        { key: 'hp_', value: 4.7 },
+        { key: 'atk', value: 33 },
+      ],
+      totalRolls: 5, // substats.length=4 なので enhTotal=1
+    })
+    const rollCounts = [1, 0, 0, 0]
+    const rate = calculateReconstructionRate(art, rollCounts, 'CV', 'absolute')
+    expect(rate).toBeNull()
+  })
+
   it('メインステ eleMas で攻撃型: オッズは0%を返す', () => {
     const art = makeArtifact({
       slotKey: 'sands',

--- a/webapp/src/lib/__tests__/validateGoodFile.test.ts
+++ b/webapp/src/lib/__tests__/validateGoodFile.test.ts
@@ -160,6 +160,11 @@ describe('validateGoodFile', () => {
       expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(true)
     })
 
+    it('totalRolls が 13 の場合を拒否する（上限 12 を超えている）', () => {
+      const artifact = { ...validArtifact, totalRolls: 13 }
+      expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(false)
+    })
+
     it('totalRolls が 0 の場合は受け入れる', () => {
       const artifact = { ...validArtifact, totalRolls: 0 }
       expect(validateGoodFile({ format: 'GOOD', artifacts: [artifact] })).toBe(true)


### PR DESCRIPTION
Issue #233 に基づくテストカバレッジ改善です。

## 変更内容

- `validateGoodFile.test.ts`: totalRolls=13 の境界値テスト追加
- `reconstruction.test.ts`: totalFilteredProb===0 ケーステスト追加
- `estimateRollCounts.test.ts`: remainder > substats.length のフォールバックエッジケース
- `i18n.test.ts` (新規): en/ja 翻訳キー構造一致テスト

Closes #233

Generated with [Claude Code](https://claude.ai/code)