### PR TITLE
refactor: 保守性改善 (#237)

### DIFF
--- a/webapp/src/app/page.tsx
+++ b/webapp/src/app/page.tsx
@@ -1,14 +1,16 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import ArtifactCard from '@/components/ArtifactCard'
 import HeroSection from '@/components/HeroSection'
 import ControlsBar from '@/components/ControlsBar'
-import type { GoodFile, RankedArtifact, ReconstructionType, ScoreTypeName, StatKey } from '@/lib/types'
+import type { GoodFile, ReconstructionType, ScoreTypeName, StatKey } from '@/lib/types'
 import { groupSetOptions, SCORE_TYPE_OPTIONS, ALL_SUBSTAT_KEYS } from '@/lib/constants'
 import { useTranslation } from '@/lib/i18n'
 import { getAllStatNames } from '@/lib/i18n/types'
 import { useArtifactFilters } from '@/hooks/useArtifactFilters'
+import { useArtifactData } from '@/hooks/useArtifactData'
+import { useDisplayedArtifacts } from '@/hooks/useDisplayedArtifacts'
 
 const MAIN_STAT_ORDER: string[] = [
   'critRate_', 'critDMG_', 'atk_', 'hp_', 'def_',
@@ -18,30 +20,18 @@ const MAIN_STAT_ORDER: string[] = [
   'atk', 'hp', 'def',
 ]
 
-/** GOODファイルを読み込んで★5聖遺物をランク付けする */
-async function buildRankedList(data: GoodFile): Promise<RankedArtifact[]> {
-  const { calculateScores, calculateAllScores, estimateRollCounts } = await import('@/lib/scoring')
-  return data.artifacts
-    .filter((a) => a.rarity === 5)
-    .map((artifact) => {
-      const { cvScore, bestScore, bestType } = calculateScores(artifact)
-      const allScores = calculateAllScores(artifact)
-      const rollCounts = estimateRollCounts(artifact)
-      return { artifact, cvScore, bestScore, bestType, allScores, rollCounts }
-    })
-}
-
 export default function HomePage() {
   const { t } = useTranslation()
   const filters = useArtifactFilters()
-  const [allRanked, setAllRanked] = useState<RankedArtifact[] | null>(null)
   const [scoreType, setScoreType] = useState<ScoreTypeName>('攻撃型')
   const [subStatSort, setSubStatSort] = useState<StatKey | ''>('')
   const [reconType, setReconType] = useState<ReconstructionType>('normal')
   const [reconSort, setReconSort] = useState(false)
 
-  async function handleLoad(data: GoodFile) {
-    setAllRanked(await buildRankedList(data))
+  const { allRanked, reconRates, handleLoad } = useArtifactData(scoreType, reconType)
+
+  async function handleLoadWithReset(data: GoodFile) {
+    await handleLoad(data)
     filters.resetFilters()
   }
 
@@ -75,56 +65,14 @@ export default function HomePage() {
     return map
   }, [allRanked])
 
-  const [reconRates, setReconRates] = useState<Map<number, number>>(new Map())
-  useEffect(() => {
-    if (!allRanked) {
-      setReconRates(new Map())
-      return
-    }
-    let cancelled = false
-    import('@/lib/reconstruction').then(({ calculateReconstructionRate }) => {
-      if (cancelled) return
-      const map = new Map<number, number>()
-      for (let i = 0; i < allRanked.length; i++) {
-        const e = allRanked[i]
-        const rate = calculateReconstructionRate(e.artifact, e.rollCounts, scoreType, reconType)
-        if (rate !== null) map.set(i, rate)
-      }
-      setReconRates(map)
-    })
-    return () => { cancelled = true }
-  }, [allRanked, scoreType, reconType])
-
-  const displayed = useMemo(() => {
-    if (!allRanked) return []
-    return allRanked
-      .map((e, i) => ({ entry: e, reconRate: reconRates.get(i) ?? null, originalIndex: i }))
-      .filter(({ entry: e }) => filters.filterSets.length === 0 || filters.filterSets.includes(e.artifact.setKey))
-      .filter(({ entry: e }) => !filters.filterSlot || e.artifact.slotKey === filters.filterSlot)
-      .filter(({ entry: e }) => !filters.filterMainStat || e.artifact.mainStatKey === filters.filterMainStat)
-      .filter(({ entry: e }) =>
-        filters.filterSubStats.length === 0 ||
-        filters.filterSubStats.every((k) => e.artifact.substats.some((s) => s.key === k)),
-      )
-      .filter(({ entry: e }) => {
-        if (!filters.filterInitialOp) return true
-        const initialOp = e.artifact.totalRolls - Math.floor(e.artifact.level / 4)
-        return initialOp === Number(filters.filterInitialOp)
-      })
-      .sort((a, b) => {
-        if (reconSort) {
-          const ra = a.reconRate ?? -1
-          const rb = b.reconRate ?? -1
-          if (ra !== rb) return rb - ra
-        }
-        if (subStatSort) {
-          const va = a.entry.artifact.substats.find((s) => s.key === subStatSort)?.value ?? -Infinity
-          const vb = b.entry.artifact.substats.find((s) => s.key === subStatSort)?.value ?? -Infinity
-          if (va !== vb) return vb - va
-        }
-        return b.entry.allScores[scoreType] - a.entry.allScores[scoreType]
-      })
-  }, [allRanked, filters.filterSets, filters.filterSlot, filters.filterMainStat, filters.filterSubStats, filters.filterInitialOp, subStatSort, scoreType, reconRates, reconSort])
+  const displayed = useDisplayedArtifacts({
+    allRanked,
+    reconRates,
+    filters,
+    subStatSort,
+    scoreType,
+    reconSort,
+  })
 
   const allMainStatNames = getAllStatNames(t)
 
@@ -133,7 +81,7 @@ export default function HomePage() {
       <h1 className="page-title">{t.siteTitle}</h1>
 
       {allRanked === null ? (
-        <HeroSection onLoad={handleLoad} t={t} scoreTypeOptions={SCORE_TYPE_OPTIONS} />
+        <HeroSection onLoad={handleLoadWithReset} t={t} scoreTypeOptions={SCORE_TYPE_OPTIONS} />
       ) : (
         <>
           <ControlsBar

--- a/webapp/src/hooks/useArtifactData.ts
+++ b/webapp/src/hooks/useArtifactData.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import type { GoodFile, RankedArtifact, ReconstructionType, ScoreTypeName } from '@/lib/types'
+
+/** GOODファイルを読み込んで★5聖遺物をランク付けする */
+async function buildRankedList(data: GoodFile): Promise<RankedArtifact[]> {
+  const { calculateScores, calculateAllScores, estimateRollCounts } = await import('@/lib/scoring')
+  return data.artifacts
+    .filter((a) => a.rarity === 5)
+    .map((artifact) => {
+      const { cvScore, bestScore, bestType } = calculateScores(artifact)
+      const allScores = calculateAllScores(artifact)
+      const rollCounts = estimateRollCounts(artifact)
+      return { artifact, cvScore, bestScore, bestType, allScores, rollCounts }
+    })
+}
+
+/** 聖遺物データの読み込みと再構築成功率の計算を管理するフック */
+export function useArtifactData(scoreType: ScoreTypeName, reconType: ReconstructionType) {
+  const [allRanked, setAllRanked] = useState<RankedArtifact[] | null>(null)
+  const [reconRates, setReconRates] = useState<Map<number, number>>(new Map())
+
+  async function handleLoad(data: GoodFile) {
+    setAllRanked(await buildRankedList(data))
+  }
+
+  useEffect(() => {
+    if (!allRanked) {
+      setReconRates(new Map())
+      return
+    }
+    let cancelled = false
+    import('@/lib/reconstruction').then(({ calculateReconstructionRate }) => {
+      if (cancelled) return
+      const map = new Map<number, number>()
+      for (let i = 0; i < allRanked.length; i++) {
+        const e = allRanked[i]
+        const rate = calculateReconstructionRate(e.artifact, e.rollCounts, scoreType, reconType)
+        if (rate !== null) map.set(i, rate)
+      }
+      setReconRates(map)
+    })
+    return () => { cancelled = true }
+  }, [allRanked, scoreType, reconType])
+
+  return { allRanked, reconRates, handleLoad }
+}

--- a/webapp/src/hooks/useArtifactFilters.ts
+++ b/webapp/src/hooks/useArtifactFilters.ts
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import type { ArtifactSlotKey, StatKey } from '@/lib/types'
 import {
   type ArtifactFilterState,
+  type InitialOpFilter,
   INITIAL_ARTIFACT_FILTER_STATE,
   resetArtifactFilters,
   setMainStatFilter,
@@ -10,12 +11,12 @@ import {
   toggleSetGroupFilter,
 } from '@/lib/artifactFilters'
 
-export type { ArtifactFilterState }
+export type { ArtifactFilterState, InitialOpFilter }
 
 export interface ArtifactFiltersHook extends ArtifactFilterState {
   setFilterSets: (sets: string[]) => void
   setFilterSlot: (slot: ArtifactSlotKey | '') => void
-  setFilterInitialOp: (op: '' | '3' | '4') => void
+  setFilterInitialOp: (op: InitialOpFilter) => void
   resetFilters: () => void
   applyMainStat: (value: string) => void
   toggleSubStat: (key: StatKey, checked: boolean) => void

--- a/webapp/src/hooks/useDisplayedArtifacts.ts
+++ b/webapp/src/hooks/useDisplayedArtifacts.ts
@@ -1,0 +1,60 @@
+import { useMemo } from 'react'
+import type { RankedArtifact, ScoreTypeName, StatKey } from '@/lib/types'
+import type { ArtifactFilterState } from '@/lib/artifactFilters'
+
+interface DisplayedEntry {
+  entry: RankedArtifact
+  reconRate: number | null
+  originalIndex: number
+}
+
+interface UseDisplayedArtifactsParams {
+  allRanked: RankedArtifact[] | null
+  reconRates: Map<number, number>
+  filters: ArtifactFilterState
+  subStatSort: StatKey | ''
+  scoreType: ScoreTypeName
+  reconSort: boolean
+}
+
+/** フィルタ・ソート済み聖遺物リストを生成するフック */
+export function useDisplayedArtifacts({
+  allRanked,
+  reconRates,
+  filters,
+  subStatSort,
+  scoreType,
+  reconSort,
+}: UseDisplayedArtifactsParams): DisplayedEntry[] {
+  return useMemo(() => {
+    if (!allRanked) return []
+    return allRanked
+      .map((e, i) => ({ entry: e, reconRate: reconRates.get(i) ?? null, originalIndex: i }))
+      .filter(({ entry: e }) => filters.filterSets.length === 0 || filters.filterSets.includes(e.artifact.setKey))
+      .filter(({ entry: e }) => !filters.filterSlot || e.artifact.slotKey === filters.filterSlot)
+      .filter(({ entry: e }) => !filters.filterMainStat || e.artifact.mainStatKey === filters.filterMainStat)
+      .filter(({ entry: e }) =>
+        filters.filterSubStats.length === 0 ||
+        filters.filterSubStats.every((k) => e.artifact.substats.some((s) => s.key === k)),
+      )
+      .filter(({ entry: e }) => {
+        if (!filters.filterInitialOp) return true
+        // 初期サブステ数 = 全ロール数 - 強化ロール数（Lv4ごとに1回強化が入る）
+        const initialOp = e.artifact.totalRolls - Math.floor(e.artifact.level / 4)
+        return initialOp === Number(filters.filterInitialOp)
+      })
+      .sort((a, b) => {
+        if (reconSort) {
+          const ra = a.reconRate ?? -1
+          const rb = b.reconRate ?? -1
+          if (ra !== rb) return rb - ra
+        }
+        if (subStatSort) {
+          const va = a.entry.artifact.substats.find((s) => s.key === subStatSort)?.value ?? -Infinity
+          const vb = b.entry.artifact.substats.find((s) => s.key === subStatSort)?.value ?? -Infinity
+          if (va !== vb) return vb - va
+        }
+        return b.entry.allScores[scoreType] - a.entry.allScores[scoreType]
+      })
+  }, [allRanked, filters.filterSets, filters.filterSlot, filters.filterMainStat, filters.filterSubStats, filters.filterInitialOp, subStatSort, scoreType, reconRates, reconSort])
+}

--- a/webapp/src/lib/artifactFilters.ts
+++ b/webapp/src/lib/artifactFilters.ts
@@ -1,12 +1,15 @@
 import type { ArtifactSlotKey, StatKey } from '@/lib/types'
 
+/** 初期サブステ数フィルタ値（空文字=絞り込みなし、'3'=3OP、'4'=4OP） */
+export type InitialOpFilter = '' | '3' | '4'
+
 /** フィルタ状態 */
 export interface ArtifactFilterState {
   filterSets: string[]
   filterSlot: ArtifactSlotKey | ''
   filterMainStat: string
   filterSubStats: StatKey[]
-  filterInitialOp: '' | '3' | '4'
+  filterInitialOp: InitialOpFilter
 }
 
 export const INITIAL_ARTIFACT_FILTER_STATE: ArtifactFilterState = {

--- a/webapp/src/lib/constants.ts
+++ b/webapp/src/lib/constants.ts
@@ -2,6 +2,18 @@
 
 import type { ArtifactSlotKey, ScoreTypeName, StatKey } from './types'
 
+/**
+ * スコア種別の定義: [ScoreTypeName, サブステkey, 係数]
+ * scoring.ts・reconstruction.ts 両モジュールで参照する共通定数
+ */
+export const SCORE_TYPE_DEFS: [ScoreTypeName, StatKey, number][] = [
+  ['HP型', 'hp_', 1.0],
+  ['攻撃型', 'atk_', 1.0],
+  ['防御型', 'def_', 0.8],
+  ['熟知型', 'eleMas', 0.25],
+  ['チャージ型', 'enerRech_', 0.9],
+]
+
 /** スコアタイプの選択肢一覧 */
 export const SCORE_TYPE_OPTIONS: ScoreTypeName[] = [
   'CV', '攻撃型', 'HP型', '防御型', '熟知型', 'チャージ型', '最良型',

--- a/webapp/src/lib/reconstruction.ts
+++ b/webapp/src/lib/reconstruction.ts
@@ -11,7 +11,7 @@
 
 import type { Artifact, ReconstructionType, ScoreTypeName, StatKey } from './types'
 import { AVG_INCREMENT } from './scoring'
-import { TYPED_MAIN_STATS } from './constants'
+import { TYPED_MAIN_STATS, SCORE_TYPE_DEFS } from './constants'
 
 /** 再構築種別ごとの保証閾値（選択2サブステへの合計ロール数） */
 const GUARANTEE_THRESHOLDS: Record<ReconstructionType, number> = {
@@ -19,15 +19,6 @@ const GUARANTEE_THRESHOLDS: Record<ReconstructionType, number> = {
   advanced: 3,
   absolute: 4,
 }
-
-/** スコア種別ごとの追加ステ: [StatKey, 係数] */
-const SCORE_EXTRA: [ScoreTypeName, StatKey, number][] = [
-  ['HP型', 'hp_', 1.0],
-  ['攻撃型', 'atk_', 1.0],
-  ['防御型', 'def_', 0.8],
-  ['熟知型', 'eleMas', 0.25],
-  ['チャージ型', 'enerRech_', 0.9],
-]
 
 /**
  * スコアタイプと聖遺物に応じた保証サブステ候補ペアを返す
@@ -59,11 +50,11 @@ function getGuaranteedPairs(
 
   // 最良型は全固有ステを候補に
   if (scoreType === '最良型') {
-    return SCORE_EXTRA.map(([, key]) => [remainingCrit, key])
+    return SCORE_TYPE_DEFS.map(([, key]) => [remainingCrit, key])
   }
 
   // その他: スコアタイプ固有ステとペア
-  const extra = SCORE_EXTRA.find(([name]) => name === scoreType)
+  const extra = SCORE_TYPE_DEFS.find(([name]) => name === scoreType)
   if (!extra) return []
   return [[remainingCrit, extra[1]]]
 }
@@ -143,7 +134,7 @@ function calcScore(
 
   if (scoreType === '最良型') {
     let best = cv
-    for (const [, key, coeff] of SCORE_EXTRA) {
+    for (const [, key, coeff] of SCORE_TYPE_DEFS) {
       if (TYPED_MAIN_STATS.has(mainStatKey) && mainStatKey !== key) continue
       const s = cv + (subMap[key] ?? 0) * coeff
       if (s > best) best = s
@@ -151,7 +142,7 @@ function calcScore(
     return best
   }
 
-  const extra = SCORE_EXTRA.find(([name]) => name === scoreType)
+  const extra = SCORE_TYPE_DEFS.find(([name]) => name === scoreType)
   if (!extra) return cv
   if (TYPED_MAIN_STATS.has(mainStatKey) && mainStatKey !== extra[1]) return 0
   return cv + (subMap[extra[1]] ?? 0) * extra[2]

--- a/webapp/src/lib/scoring.ts
+++ b/webapp/src/lib/scoring.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Artifact, ScoreResult, ScoreTypeName, StatKey } from './types'
-import { PERCENT_STATS, TYPED_MAIN_STATS } from './constants'
+import { PERCENT_STATS, TYPED_MAIN_STATS, SCORE_TYPE_DEFS } from './constants'
 
 // サブステの4段階ティア値（低/中/高/最高）
 const SUBSTAT_TIERS: Record<StatKey, number[]> = {
@@ -40,15 +40,6 @@ export const AVG_INCREMENT: Record<StatKey, number> = {
   critRate_: 3.3,
   critDMG_: 6.6,
 }
-
-// スコア種別の定義: [ScoreTypeName, サブステkey, 係数]
-const SCORE_TYPE_DEFS: [ScoreTypeName, StatKey, number][] = [
-  ['HP型', 'hp_', 1.0],
-  ['攻撃型', 'atk_', 1.0],
-  ['防御型', 'def_', 0.8],
-  ['熟知型', 'eleMas', 0.25],
-  ['チャージ型', 'enerRech_', 0.9],
-]
 
 /** 浮動小数点回避用スケール係数 */
 function getScale(key: StatKey): number {


### PR DESCRIPTION
Issue #237 の保守性・可読性改善を実装します。

- SCORE_TYPE_DEFS を constants.ts に一元化（DRY 違反解消）
- useArtifactData / useDisplayedArtifacts カスタムフックを新規作成
- InitialOpFilter 型を追加
- initialOp 計算式にコメントを追加

closes #237

Generated with [Claude Code](https://claude.ai/code)