### PR TITLE
feat: フォント改善（next/font + tabular-nums）

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -18,7 +18,7 @@
 body {
   background-color: var(--bg-main);
   color: var(--text-main);
-  font-family: 'Noto Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif;
+  font-family: var(--font-noto-sans-jp), 'Hiragino Kaku Gothic ProN', sans-serif;
   min-height: 100vh;
 }
 
@@ -128,10 +128,10 @@ body {
 .page-title {
   text-align: center;
   font-size: 2rem;
-  font-weight: bold;
+  font-weight: 700;
   color: var(--gold);
   margin-bottom: 2rem;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
 }
 
 /* ── サイドメニューページコンテンツ ────────── */
@@ -146,6 +146,7 @@ body {
   margin-bottom: 0.75rem;
   padding-bottom: 0.4rem;
   border-bottom: 1px solid var(--border);
+  letter-spacing: 0.04em;
 }
 
 .subsection-title {
@@ -568,9 +569,10 @@ body {
 /* メインスコア（選択型 — 大きく） */
 .main-score {
   font-size: 1.8rem;
-  font-weight: bold;
+  font-weight: 700;
   letter-spacing: 0.03em;
   line-height: 1;
+  font-variant-numeric: tabular-nums;
 }
 
 .score-label {

--- a/webapp/src/app/layout.tsx
+++ b/webapp/src/app/layout.tsx
@@ -1,7 +1,16 @@
 import type { Metadata } from 'next'
+import { Noto_Sans_JP } from 'next/font/google'
 import './globals.css'
 import Sidebar from '@/components/Sidebar'
 import { LanguageProvider } from '@/lib/i18n'
+
+const notoSansJP = Noto_Sans_JP({
+  weight: ['400', '500', '600', '700'],
+  subsets: ['latin'],
+  preload: false,
+  variable: '--font-noto-sans-jp',
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
   title: 'もぐもぐパイモン - 聖遺物スコア -',
@@ -14,9 +23,9 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="ja">
+    <html lang="ja" className={notoSansJP.variable}>
       <head>
-        <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
+        <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" />
 <meta name="referrer" content="no-referrer" />
       </head>
       <body>


### PR DESCRIPTION
closes #252

- next/font/google で Noto Sans JP を正式読み込み（自己ホスト化）
- スコア数値に font-variant-numeric: tabular-nums を適用
- 見出し用フォントウェイト・レタースペーシング調整

Generated with [Claude Code](https://claude.ai/code)