### PR TITLE
perf: 再構築成功率の計算対象をフィルタ後の聖遺物のみに絞り込む

### DIFF
--- a/webapp/src/app/page.tsx
+++ b/webapp/src/app/page.tsx
@@ -28,7 +28,7 @@ export default function HomePage() {
   const [reconType, setReconType] = useState<ReconstructionType>('normal')
   const [reconSort, setReconSort] = useState(false)
 
-  const { allRanked, reconRates, handleLoad } = useArtifactData(scoreType, reconType)
+  const { allRanked, handleLoad } = useArtifactData()
 
   async function handleLoadWithReset(data: GoodFile) {
     await handleLoad(data)
@@ -67,11 +67,11 @@ export default function HomePage() {
 
   const displayed = useDisplayedArtifacts({
     allRanked,
-    reconRates,
     filters,
     subStatSort,
     scoreType,
     reconSort,
+    reconType,
   })
 
   const allMainStatNames = getAllStatNames(t)

--- a/webapp/src/hooks/useArtifactData.ts
+++ b/webapp/src/hooks/useArtifactData.ts
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
-import type { GoodFile, RankedArtifact, ReconstructionType, ScoreTypeName } from '@/lib/types'
+import { useState } from 'react'
+import type { GoodFile, RankedArtifact } from '@/lib/types'
 
 /** GOODファイルを読み込んで★5聖遺物をランク付けする（チャンク処理でUIブロックを防ぐ） */
 async function buildRankedList(data: GoodFile): Promise<RankedArtifact[]> {
@@ -26,72 +26,13 @@ async function buildRankedList(data: GoodFile): Promise<RankedArtifact[]> {
   return result
 }
 
-/** 聖遺物データの読み込みと再構築成功率のチャンク計算を管理するフック */
-export function useArtifactData(scoreType: ScoreTypeName, reconType: ReconstructionType) {
+/** 聖遺物データの読み込みを管理するフック（再構築成功率はフィルタ後に計算） */
+export function useArtifactData() {
   const [allRanked, setAllRanked] = useState<RankedArtifact[] | null>(null)
-  const [reconRates, setReconRates] = useState<Map<number, number>>(new Map())
-
-  // scoreType × reconType の組み合わせで計算済みの再構築率をキャッシュ
-  const reconCacheRef = useRef<Map<string, Map<number, number>>>(new Map())
-  // allRanked の参照を追跡してデータ変更時にキャッシュをクリア
-  const cachedAllRankedRef = useRef<RankedArtifact[] | null>(null)
 
   async function handleLoad(data: GoodFile) {
     setAllRanked(await buildRankedList(data))
   }
 
-  useEffect(() => {
-    if (!allRanked) {
-      reconCacheRef.current = new Map()
-      cachedAllRankedRef.current = null
-      setReconRates(new Map())
-      return
-    }
-
-    // 新しいファイルが読み込まれたらキャッシュをクリア
-    if (cachedAllRankedRef.current !== allRanked) {
-      reconCacheRef.current = new Map()
-      cachedAllRankedRef.current = allRanked
-    }
-
-    const cacheKey = `${scoreType}:${reconType}`
-    const cached = reconCacheRef.current.get(cacheKey)
-    if (cached) {
-      // キャッシュ済みなら即時反映
-      setReconRates(cached)
-      return
-    }
-
-    let cancelled = false
-    const CHUNK_SIZE = 100
-    import('@/lib/reconstruction').then(({ calculateReconstructionRate }) => {
-      if (cancelled) return
-      const map = new Map<number, number>()
-      let idx = 0
-
-      function processChunk() {
-        if (cancelled) return
-        const end = Math.min(idx + CHUNK_SIZE, allRanked!.length)
-        for (; idx < end; idx++) {
-          const e = allRanked![idx]
-          const rate = calculateReconstructionRate(e.artifact, e.rollCounts, scoreType, reconType)
-          if (rate !== null) map.set(idx, rate)
-        }
-        if (idx < allRanked!.length) {
-          setReconRates(new Map(map))
-          setTimeout(processChunk, 0)
-        } else {
-          // 計算完了時にキャッシュへ保存してから反映
-          const finalMap = new Map(map)
-          reconCacheRef.current.set(cacheKey, finalMap)
-          setReconRates(finalMap)
-        }
-      }
-
-      processChunk()
-    })
-    return () => { cancelled = true }
-  }, [allRanked, scoreType, reconType])
-
-  return { allRanked, reconRates, handleLoad }
+  return { allRanked, handleLoad }
 }

--- a/webapp/src/hooks/useDisplayedArtifacts.ts
+++ b/webapp/src/hooks/useDisplayedArtifacts.ts
@@ -1,5 +1,5 @@
-import { useMemo } from 'react'
-import type { RankedArtifact, ScoreTypeName, StatKey } from '@/lib/types'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { RankedArtifact, ReconstructionType, ScoreTypeName, StatKey } from '@/lib/types'
 import type { ArtifactFilterState } from '@/lib/artifactFilters'
 
 interface DisplayedEntry {
@@ -8,28 +8,34 @@ interface DisplayedEntry {
   originalIndex: number
 }
 
+interface FilteredEntry {
+  entry: RankedArtifact
+  originalIndex: number
+}
+
 interface UseDisplayedArtifactsParams {
   allRanked: RankedArtifact[] | null
-  reconRates: Map<number, number>
   filters: ArtifactFilterState
   subStatSort: StatKey | ''
   scoreType: ScoreTypeName
   reconSort: boolean
+  reconType: ReconstructionType
 }
 
-/** フィルタ・ソート済み聖遺物リストを生成するフック */
+/** フィルタ・ソート済み聖遺物リストを生成するフック（再構築成功率はフィルタ後の対象のみ計算） */
 export function useDisplayedArtifacts({
   allRanked,
-  reconRates,
   filters,
   subStatSort,
   scoreType,
   reconSort,
+  reconType,
 }: UseDisplayedArtifactsParams): DisplayedEntry[] {
-  return useMemo(() => {
+  // Step 1: フィルタを同期的に適用（reconRates に依存しない）
+  const filtered: FilteredEntry[] = useMemo(() => {
     if (!allRanked) return []
     return allRanked
-      .map((e, i) => ({ entry: e, reconRate: reconRates.get(i) ?? null, originalIndex: i }))
+      .map((e, i) => ({ entry: e, originalIndex: i }))
       .filter(({ entry: e }) => filters.filterSets.length === 0 || filters.filterSets.includes(e.artifact.setKey))
       .filter(({ entry: e }) => !filters.filterSlot || e.artifact.slotKey === filters.filterSlot)
       .filter(({ entry: e }) => !filters.filterMainStat || e.artifact.mainStatKey === filters.filterMainStat)
@@ -43,6 +49,90 @@ export function useDisplayedArtifacts({
         const initialOp = e.artifact.totalRolls - Math.floor(e.artifact.level / 4)
         return initialOp === Number(filters.filterInitialOp)
       })
+  }, [allRanked, filters.filterSets, filters.filterSlot, filters.filterMainStat, filters.filterSubStats, filters.filterInitialOp])
+
+  // Step 2: フィルタ済み聖遺物のみ再構築成功率を非同期計算
+  const [reconRates, setReconRates] = useState<Map<number, number>>(new Map())
+  // scoreType:reconType をキーとして、originalIndex → rate をキャッシュ
+  const reconCacheRef = useRef<Map<string, Map<number, number>>>(new Map())
+  // allRanked の変更を追跡してキャッシュをクリア
+  const cachedAllRankedRef = useRef<RankedArtifact[] | null>(null)
+
+  useEffect(() => {
+    if (!allRanked || filtered.length === 0) {
+      setReconRates(new Map())
+      return
+    }
+
+    // 新しいファイルが読み込まれたらキャッシュをクリア
+    if (cachedAllRankedRef.current !== allRanked) {
+      reconCacheRef.current = new Map()
+      cachedAllRankedRef.current = allRanked
+    }
+
+    const cacheKey = `${scoreType}:${reconType}`
+    let perArtifactCache = reconCacheRef.current.get(cacheKey)
+    if (!perArtifactCache) {
+      perArtifactCache = new Map()
+      reconCacheRef.current.set(cacheKey, perArtifactCache)
+    }
+    const cache = perArtifactCache
+
+    // キャッシュにない（未計算）聖遺物を抽出
+    const toCompute = filtered.filter((f) => !cache.has(f.originalIndex))
+
+    if (toCompute.length === 0) {
+      // すべてキャッシュ済み — フィルタ分の結果をすぐに反映
+      const result = new Map<number, number>()
+      for (const { originalIndex } of filtered) {
+        const rate = cache.get(originalIndex)
+        if (rate !== undefined) result.set(originalIndex, rate)
+      }
+      setReconRates(result)
+      return
+    }
+
+    let cancelled = false
+    const CHUNK_SIZE = 100
+    import('@/lib/reconstruction').then(({ calculateReconstructionRate }) => {
+      if (cancelled) return
+      let i = 0
+
+      function processChunk() {
+        if (cancelled) return
+        const end = Math.min(i + CHUNK_SIZE, toCompute.length)
+        for (; i < end; i++) {
+          const { entry, originalIndex } = toCompute[i]
+          const rate = calculateReconstructionRate(entry.artifact, entry.rollCounts, scoreType, reconType)
+          if (rate !== null) cache.set(originalIndex, rate)
+        }
+
+        // フィルタ済み全件分の現在の結果を反映
+        const result = new Map<number, number>()
+        for (const { originalIndex } of filtered) {
+          const rate = cache.get(originalIndex)
+          if (rate !== undefined) result.set(originalIndex, rate)
+        }
+        setReconRates(new Map(result))
+
+        if (i < toCompute.length) {
+          setTimeout(processChunk, 0)
+        }
+      }
+
+      processChunk()
+    })
+    return () => { cancelled = true }
+  }, [filtered, scoreType, reconType, allRanked])
+
+  // Step 3: reconRates を使ってソート
+  return useMemo(() => {
+    return filtered
+      .map(({ entry, originalIndex }) => ({
+        entry,
+        reconRate: reconRates.get(originalIndex) ?? null,
+        originalIndex,
+      }))
       .sort((a, b) => {
         if (reconSort) {
           const ra = a.reconRate ?? -1
@@ -56,5 +146,5 @@ export function useDisplayedArtifacts({
         }
         return b.entry.allScores[scoreType] - a.entry.allScores[scoreType]
       })
-  }, [allRanked, filters.filterSets, filters.filterSlot, filters.filterMainStat, filters.filterSubStats, filters.filterInitialOp, subStatSort, scoreType, reconRates, reconSort])
+  }, [filtered, reconRates, reconSort, subStatSort, scoreType])
 }


### PR DESCRIPTION
Closes #261

再構築成功率の計算対象を全★5聖遺物から、フィルタ後の表示対象のみに絞り込む。

Generated with [Claude Code](https://claude.ai/code)