### PR TITLE
feat: UI改善 聖遺物カードの強化 (#270)

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -527,18 +527,21 @@ body {
 /* ── 聖遺物カード ──────────────────────── */
 .artifact-card {
   position: relative;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
+  background: rgba(26, 27, 46, 0.82);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border: 1px solid rgba(46, 48, 80, 0.8);
   border-radius: 12px;
   padding: 1rem;
-  transition: background 0.2s, transform 0.2s;
+  transition: background 0.2s, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.25s;
   animation: card-drop-in 250ms ease-out both;
   animation-delay: var(--card-anim-delay, 0ms);
 }
 
 .artifact-card:hover {
-  background: var(--bg-card-hover);
-  transform: translateY(-2px);
+  background: rgba(34, 36, 58, 0.92);
+  transform: translateY(-4px);
+  box-shadow: 0 8px 32px rgba(200, 163, 90, 0.22), 0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 /* ── スコアバー ─────────────────────────── */
@@ -669,6 +672,22 @@ body {
   color: var(--text-sub);
 }
 
+/* スコアランクバッジ（S/A/B/C） */
+.score-rank-badge {
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.1rem 0.45rem;
+  border-radius: 4px;
+  margin-left: auto;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+
+.rank-s { color: #ef4444; background: rgba(239, 68, 68, 0.15); border: 1px solid rgba(239, 68, 68, 0.45); }
+.rank-a { color: #f97316; background: rgba(249, 115, 22, 0.15); border: 1px solid rgba(249, 115, 22, 0.45); }
+.rank-b { color: #eab308; background: rgba(234, 179, 8, 0.15); border: 1px solid rgba(234, 179, 8, 0.45); }
+.rank-c { color: var(--text-sub); background: rgba(156, 163, 175, 0.08); border: 1px solid rgba(156, 163, 175, 0.2); }
+
 /* ── サブステ一覧 ────────────────────────── */
 .substats {
   display: flex;
@@ -710,6 +729,26 @@ body {
 }
 .substat-effective .substat-rolls {
   color: #ca8a04;
+}
+
+/* ── サブステロールブロック ──────────────── */
+.substat-roll-bars {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding-left: 0.3rem;
+}
+
+.roll-block {
+  width: 6px;
+  height: 10px;
+  border-radius: 2px;
+  background: rgba(120, 125, 160, 0.45);
+  flex-shrink: 0;
+}
+
+.substat-effective .roll-block {
+  background: rgba(202, 138, 4, 0.75);
 }
 
 
@@ -876,26 +915,32 @@ body {
 }
 
 /* ── 再構築成功率 ────────────────────────── */
-.recon-rate {
+.recon-rate-wrap {
   display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+
+.recon-rate-badge {
+  display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  margin-top: 0.5rem;
-  justify-content: flex-end;
+  padding: 0.15rem 0.55rem;
+  border-radius: 4px;
 }
 
 .recon-icon {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   object-fit: contain;
 }
 
-.recon-rate-red { color: #ef4444; }
-.recon-rate-orange { color: #f97316; }
-.recon-rate-grey { color: #6b7280; }
+.recon-rate-red    { color: #ef4444; background: rgba(239, 68, 68, 0.15); border: 1px solid rgba(239, 68, 68, 0.4); }
+.recon-rate-orange { color: #f97316; background: rgba(249, 115, 22, 0.15); border: 1px solid rgba(249, 115, 22, 0.4); }
+.recon-rate-grey   { color: #22c55e; background: rgba(34, 197, 94, 0.12); border: 1px solid rgba(34, 197, 94, 0.35); }
 
 /* ── コンテキストメニュー ────────────────── */
 .context-menu {

--- a/webapp/src/components/ArtifactCard.tsx
+++ b/webapp/src/components/ArtifactCard.tsx
@@ -50,6 +50,22 @@ function formatSubstat(
   return { label, valueStr, rollDetail }
 }
 
+/** スコアのランク文字を返す */
+function scoreRank(score: number): string {
+  if (score >= 55) return 'S'
+  if (score >= 45) return 'A'
+  if (score >= 35) return 'B'
+  return 'C'
+}
+
+/** スコアランクバッジの CSS クラスを返す */
+function scoreRankClass(score: number): string {
+  if (score >= 55) return 'rank-s'
+  if (score >= 45) return 'rank-a'
+  if (score >= 35) return 'rank-b'
+  return 'rank-c'
+}
+
 /** スコアバーの色クラスを返す */
 function scoreBarColor(score: number): string {
   if (score >= 55) return 'score-bar-red'
@@ -224,6 +240,10 @@ export default function ArtifactCard({ entry, scoreType, reconRate, onFilterBySe
         {showCvSub && (
           <div className="cv-sub">CV {cvScore.toFixed(1)}</div>
         )}
+        {/* ランクバッジ（S/A/B/C） */}
+        <span className={`score-rank-badge ${scoreRankClass(mainScore)}`}>
+          {scoreRank(mainScore)}
+        </span>
       </div>
 
       {/* スコアバー（0から伸びるアニメーション） */}
@@ -238,13 +258,18 @@ export default function ArtifactCard({ entry, scoreType, reconRate, onFilterBySe
       <div className="substats">
         {substats.map((s, i) => {
           const upgradeRolls = rollCounts[i] ?? 0
-          const { label, valueStr, rollDetail } = formatSubstat(s.key, s.value, upgradeRolls, t.stats)
+          const { label, valueStr } = formatSubstat(s.key, s.value, upgradeRolls, t.stats)
           const isEffective = effectiveStats.has(s.key as StatKey)
+          const totalRolls = upgradeRolls + 1
           return (
             <div key={i} className={`substat-row${isEffective ? ' substat-effective' : ''}`}>
               <span className="substat-name">{label}</span>
               <span className="substat-value">{valueStr}</span>
-              <span className="substat-rolls">{rollDetail}</span>
+              <span className="substat-roll-bars">
+                {Array.from({ length: totalRolls }).map((_, j) => (
+                  <span key={j} className="roll-block" />
+                ))}
+              </span>
             </div>
           )
         })}
@@ -252,14 +277,16 @@ export default function ArtifactCard({ entry, scoreType, reconRate, onFilterBySe
 
       {/* 再構築成功率 */}
       {reconRate != null && (
-        <div className={`recon-rate ${reconColor(reconRate)}`}>
-          <img
-            src={`${bp}/icons/Item_Dust_of_Enlightenment.webp`}
-            alt="聖啓の塵"
-            className="recon-icon"
-            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
-          />
-          {Math.round(reconRate)}%
+        <div className="recon-rate-wrap">
+          <span className={`recon-rate-badge ${reconColor(reconRate)}`}>
+            <img
+              src={`${bp}/icons/Item_Dust_of_Enlightenment.webp`}
+              alt="聖啓の塵"
+              className="recon-icon"
+              onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
+            />
+            {Math.round(reconRate)}%
+          </span>
         </div>
       )}
 


### PR DESCRIPTION
## 概要

Issue #270 の聖遺物カードUI強化を実装。

## 変更内容

- スコアランクバッジ（S/A/B/C）
- グラスモーフィズム（backdrop-filter blur）
- ホバーエフェクト強化（translateY(-4px) + gold glow）
- サブステロール数カラーブロック表示
- 再構成率バッジ化

Closes #270

Generated with [Claude Code](https://claude.ai/code)