### PR TITLE
feat: UI改善: コントロールバーの改善 (#271)

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -320,15 +320,132 @@ body {
 
 /* ── コントロールバー ───────────────────── */
 .controls-bar {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
-  gap: 1rem;
-  align-items: end;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
   margin-bottom: 1.25rem;
   padding: 0.75rem 1rem;
   background: var(--bg-ctrl);
   border: 1px solid var(--border);
   border-radius: 10px;
+}
+
+.ctrl-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: flex-start;
+}
+
+.ctrl-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.ctrl-section-filter {
+  flex: 1;
+}
+
+.ctrl-section-label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: var(--gold-light);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.ctrl-section-body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: flex-end;
+}
+
+.ctrl-advanced-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: flex-end;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+  margin-top: 0.15rem;
+}
+
+.ctrl-advanced-btn {
+  background: var(--bg-card);
+  color: var(--text-sub);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.82rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  white-space: nowrap;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.ctrl-advanced-btn:hover {
+  color: var(--gold);
+  border-color: var(--gold);
+}
+
+.ctrl-advanced-btn.ctrl-advanced-open {
+  color: var(--gold);
+  border-color: var(--gold);
+}
+
+.ctrl-advanced-arrow {
+  font-size: 0.65rem;
+}
+
+.ctrl-active {
+  border-color: var(--gold) !important;
+  color: var(--gold-light) !important;
+}
+
+.ctrl-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+  padding-top: 0.1rem;
+}
+
+.ctrl-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.55rem;
+  background: color-mix(in srgb, var(--gold) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--gold) 50%, transparent);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  color: var(--gold-light);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+.ctrl-filter-chip:hover {
+  background: color-mix(in srgb, var(--gold) 25%, transparent);
+  border-color: var(--gold);
+}
+
+.ctrl-chip-close {
+  font-size: 0.9rem;
+  line-height: 1;
+  opacity: 0.7;
+}
+
+.ctrl-filter-chip:hover .ctrl-chip-close {
+  opacity: 1;
 }
 
 .ctrl-group {

--- a/webapp/src/components/ControlsBar.tsx
+++ b/webapp/src/components/ControlsBar.tsx
@@ -45,6 +45,7 @@ export default function ControlsBar({
 }: ControlsBarProps) {
   const [subStatOpen, setSubStatOpen] = useState(false)
   const [setFilterOpen, setSetFilterOpen] = useState(false)
+  const [advancedOpen, setAdvancedOpen] = useState(false)
   const subStatBtnRef = useRef<HTMLButtonElement>(null)
   const subStatPanelRef = useRef<HTMLDivElement>(null)
   const setFilterBtnRef = useRef<HTMLButtonElement>(null)
@@ -80,224 +81,301 @@ export default function ControlsBar({
     { value: 'circlet', label: t.slots.circlet },
   ]
 
+  const hasFilter = hasActiveFilter(
+    filters.filterSets,
+    filters.filterSlot,
+    filters.filterMainStat,
+    filters.filterSubStats,
+    filters.filterInitialOp,
+  )
+
+  // アクティブフィルターのチップ一覧
+  const filterChips: { label: string; onRemove: () => void }[] = []
+
+  if (filters.filterSlot) {
+    const slotLabel = SLOT_OPTIONS.find((o) => o.value === filters.filterSlot)?.label ?? filters.filterSlot
+    filterChips.push({ label: slotLabel, onRemove: () => filters.setFilterSlot('') })
+  }
+  if (filters.filterMainStat) {
+    const mainStatLabel = allMainStatNames[filters.filterMainStat] ?? MAIN_STAT_NAMES[filters.filterMainStat] ?? filters.filterMainStat
+    filterChips.push({ label: mainStatLabel, onRemove: () => filters.applyMainStat('') })
+  }
+  if (filters.filterInitialOp) {
+    const opLabel = filters.filterInitialOp === '3' ? t.controls.op3 : t.controls.op4
+    filterChips.push({ label: opLabel, onRemove: () => filters.setFilterInitialOp('') })
+  }
+  for (const key of filters.filterSubStats) {
+    const subStatLabel = t.stats[key] ?? STAT_NAMES[key]
+    filterChips.push({ label: subStatLabel, onRemove: () => filters.toggleSubStat(key, false) })
+  }
+  for (const key of filters.filterSets) {
+    const setLabel = t.artifactSetNames[key] ?? ARTIFACT_SET_NAMES[key] ?? key
+    filterChips.push({ label: setLabel, onRemove: () => filters.toggleSet(key, false) })
+  }
+
   return (
     <div className="controls-bar">
-      {/* スコアタイプ */}
-      <div className="ctrl-group">
-        <label className="ctrl-label">{t.controls.scoreType}</label>
-        <select
-          className="ctrl-select"
-          value={scoreType}
-          onChange={(e) => setScoreType(e.target.value as ScoreTypeName)}
-        >
-          {SCORE_TYPE_OPTIONS.map((type) => (
-            <option key={type} value={type}>{t.scoreFormulas[type].label}</option>
-          ))}
-        </select>
-      </div>
+      <div className="ctrl-row">
+        {/* グループA: スコア設定 */}
+        <div className="ctrl-section">
+          <div className="ctrl-section-label">{t.controls.groupScore}</div>
+          <div className="ctrl-section-body">
+            <div className="ctrl-group">
+              <label className="ctrl-label">{t.controls.scoreType}</label>
+              <select
+                className="ctrl-select"
+                value={scoreType}
+                onChange={(e) => setScoreType(e.target.value as ScoreTypeName)}
+              >
+                {SCORE_TYPE_OPTIONS.map((type) => (
+                  <option key={type} value={type}>{t.scoreFormulas[type].label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
 
-      {/* セットフィルタ */}
-      <div className="ctrl-group">
-        <label className="ctrl-label">{t.controls.set}</label>
-        <button
-          ref={setFilterBtnRef}
-          type="button"
-          className="substat-dropdown-btn"
-          onClick={() => setSetFilterOpen((v) => !v)}
-        >
-          {filters.filterSets.length > 0
-            ? `${t.controls.set}(${filters.filterSets.length})`
-            : t.controls.set}
-        </button>
-        {setFilterOpen && createPortal(
-          <div
-            ref={setFilterPanelRef}
-            className="set-dropdown-panel"
-            style={{
-              top: (setFilterBtnRef.current?.getBoundingClientRect().bottom ?? 0) + 4,
-              left: setFilterBtnRef.current?.getBoundingClientRect().left ?? 0,
-            }}
-          >
-            {setOptionGroups.map((group) => {
-              const allSelected = group.keys.every((k) => filters.filterSets.includes(k))
-              const someSelected = group.keys.some((k) => filters.filterSets.includes(k))
-              const groupLabel = t.setGroupLabels[group.label] ?? group.label
-              return (
-                <div key={group.label}>
-                  <label className="set-group-header">
-                    <input
-                      type="checkbox"
-                      className="ctrl-checkbox"
-                      checked={allSelected}
-                      ref={(el) => {
-                        if (el) el.indeterminate = someSelected && !allSelected
-                      }}
-                      onChange={() => filters.toggleSetGroup(group.keys, allSelected)}
-                    />
-                    {groupLabel}
-                  </label>
-                  {group.keys.map((key) => (
-                    <label key={key} className="substat-dropdown-item set-item">
-                      <input
-                        type="checkbox"
-                        className="ctrl-checkbox"
-                        checked={filters.filterSets.includes(key)}
-                        onChange={(e) => filters.toggleSet(key, e.target.checked)}
-                      />
-                      {t.artifactSetNames[key] ?? ARTIFACT_SET_NAMES[key] ?? key}
-                    </label>
-                  ))}
-                </div>
-              )
-            })}
-          </div>,
-          document.body,
-        )}
-      </div>
+        {/* グループB: フィルター */}
+        <div className="ctrl-section ctrl-section-filter">
+          <div className="ctrl-section-label">{t.controls.groupFilter}</div>
+          <div className="ctrl-section-body">
+            {/* セットフィルタ */}
+            <div className="ctrl-group">
+              <label className="ctrl-label">{t.controls.set}</label>
+              <button
+                ref={setFilterBtnRef}
+                type="button"
+                className={`substat-dropdown-btn${filters.filterSets.length > 0 ? ' ctrl-active' : ''}`}
+                onClick={() => setSetFilterOpen((v) => !v)}
+              >
+                {filters.filterSets.length > 0
+                  ? `${t.controls.set}(${filters.filterSets.length})`
+                  : t.controls.set}
+              </button>
+              {setFilterOpen && createPortal(
+                <div
+                  ref={setFilterPanelRef}
+                  className="set-dropdown-panel"
+                  style={{
+                    top: (setFilterBtnRef.current?.getBoundingClientRect().bottom ?? 0) + 4,
+                    left: setFilterBtnRef.current?.getBoundingClientRect().left ?? 0,
+                  }}
+                >
+                  {setOptionGroups.map((group) => {
+                    const allSelected = group.keys.every((k) => filters.filterSets.includes(k))
+                    const someSelected = group.keys.some((k) => filters.filterSets.includes(k))
+                    const groupLabel = t.setGroupLabels[group.label] ?? group.label
+                    return (
+                      <div key={group.label}>
+                        <label className="set-group-header">
+                          <input
+                            type="checkbox"
+                            className="ctrl-checkbox"
+                            checked={allSelected}
+                            ref={(el) => {
+                              if (el) el.indeterminate = someSelected && !allSelected
+                            }}
+                            onChange={() => filters.toggleSetGroup(group.keys, allSelected)}
+                          />
+                          {groupLabel}
+                        </label>
+                        {group.keys.map((key) => (
+                          <label key={key} className="substat-dropdown-item set-item">
+                            <input
+                              type="checkbox"
+                              className="ctrl-checkbox"
+                              checked={filters.filterSets.includes(key)}
+                              onChange={(e) => filters.toggleSet(key, e.target.checked)}
+                            />
+                            {t.artifactSetNames[key] ?? ARTIFACT_SET_NAMES[key] ?? key}
+                          </label>
+                        ))}
+                      </div>
+                    )
+                  })}
+                </div>,
+                document.body,
+              )}
+            </div>
 
-      {/* 部位フィルタ */}
-      <div className="ctrl-group">
-        <label className="ctrl-label">{t.controls.slot}</label>
-        <select
-          className="ctrl-select"
-          value={filters.filterSlot}
-          onChange={(e) => filters.setFilterSlot(e.target.value as ArtifactSlotKey | '')}
-        >
-          {SLOT_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>{opt.label}</option>
-          ))}
-        </select>
-      </div>
+            {/* 部位フィルタ */}
+            <div className="ctrl-group">
+              <label className="ctrl-label">{t.controls.slot}</label>
+              <select
+                className={`ctrl-select${filters.filterSlot ? ' ctrl-active' : ''}`}
+                value={filters.filterSlot}
+                onChange={(e) => filters.setFilterSlot(e.target.value as ArtifactSlotKey | '')}
+              >
+                {SLOT_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
 
-      {/* メインステフィルタ */}
-      <div className="ctrl-group">
-        <label className="ctrl-label">{t.controls.mainStat}</label>
-        <select
-          className="ctrl-select"
-          value={filters.filterMainStat}
-          onChange={(e) => filters.applyMainStat(e.target.value)}
-        >
-          <option value="">{t.controls.allMainStats}</option>
-          {mainStatOptions.map((key) => (
-            <option key={key} value={key}>
-              {allMainStatNames[key] ?? MAIN_STAT_NAMES[key] ?? key}
-            </option>
-          ))}
-        </select>
-      </div>
+            {/* メインステフィルタ */}
+            <div className="ctrl-group">
+              <label className="ctrl-label">{t.controls.mainStat}</label>
+              <select
+                className={`ctrl-select${filters.filterMainStat ? ' ctrl-active' : ''}`}
+                value={filters.filterMainStat}
+                onChange={(e) => filters.applyMainStat(e.target.value)}
+              >
+                <option value="">{t.controls.allMainStats}</option>
+                {mainStatOptions.map((key) => (
+                  <option key={key} value={key}>
+                    {allMainStatNames[key] ?? MAIN_STAT_NAMES[key] ?? key}
+                  </option>
+                ))}
+              </select>
+            </div>
 
-      {/* 初期OPフィルタ */}
-      <div className="ctrl-group">
-        <label className="ctrl-label">{t.controls.initialOp}</label>
-        <select
-          className="ctrl-select"
-          value={filters.filterInitialOp}
-          onChange={(e) => filters.setFilterInitialOp(e.target.value as '' | '3' | '4')}
-        >
-          <option value="">{t.controls.allOps}</option>
-          <option value="3">{t.controls.op3}</option>
-          <option value="4">{t.controls.op4}</option>
-        </select>
-      </div>
+            {/* 詳細フィルタートグル */}
+            <div className="ctrl-group">
+              <div className="ctrl-label">&nbsp;</div>
+              <button
+                type="button"
+                className={`ctrl-advanced-btn${advancedOpen ? ' ctrl-advanced-open' : ''}${(filters.filterInitialOp || filters.filterSubStats.length > 0) ? ' ctrl-active' : ''}`}
+                onClick={() => setAdvancedOpen((v) => !v)}
+              >
+                {t.controls.advancedFilter}
+                <span className="ctrl-advanced-arrow">{advancedOpen ? '▲' : '▼'}</span>
+              </button>
+            </div>
+          </div>
 
-      {/* サブステフィルタ */}
-      <div className="ctrl-group">
-        <label className="ctrl-label">{t.controls.substatFilter}</label>
-        <button
-          ref={subStatBtnRef}
-          type="button"
-          className="substat-dropdown-btn"
-          onClick={() => setSubStatOpen((v) => !v)}
-        >
-          {filters.filterSubStats.length > 0
-            ? `${t.controls.substatBtn}(${filters.filterSubStats.length})`
-            : t.controls.substatBtn}
-        </button>
-        {subStatOpen && createPortal(
-          <div
-            ref={subStatPanelRef}
-            className="substat-dropdown-panel"
-            style={{
-              top: (subStatBtnRef.current?.getBoundingClientRect().bottom ?? 0) + 4,
-              left: subStatBtnRef.current?.getBoundingClientRect().left ?? 0,
-            }}
-          >
-            {availableSubStatKeys.map((key) => (
-              <label key={key} className="substat-dropdown-item">
+          {/* 詳細フィルターパネル */}
+          {advancedOpen && (
+            <div className="ctrl-advanced-panel">
+              {/* 初期OPフィルタ */}
+              <div className="ctrl-group">
+                <label className="ctrl-label">{t.controls.initialOp}</label>
+                <select
+                  className={`ctrl-select${filters.filterInitialOp ? ' ctrl-active' : ''}`}
+                  value={filters.filterInitialOp}
+                  onChange={(e) => filters.setFilterInitialOp(e.target.value as '' | '3' | '4')}
+                >
+                  <option value="">{t.controls.allOps}</option>
+                  <option value="3">{t.controls.op3}</option>
+                  <option value="4">{t.controls.op4}</option>
+                </select>
+              </div>
+
+              {/* サブステフィルタ */}
+              <div className="ctrl-group">
+                <label className="ctrl-label">{t.controls.substatFilter}</label>
+                <button
+                  ref={subStatBtnRef}
+                  type="button"
+                  className={`substat-dropdown-btn${filters.filterSubStats.length > 0 ? ' ctrl-active' : ''}`}
+                  onClick={() => setSubStatOpen((v) => !v)}
+                >
+                  {filters.filterSubStats.length > 0
+                    ? `${t.controls.substatBtn}(${filters.filterSubStats.length})`
+                    : t.controls.substatBtn}
+                </button>
+                {subStatOpen && createPortal(
+                  <div
+                    ref={subStatPanelRef}
+                    className="substat-dropdown-panel"
+                    style={{
+                      top: (subStatBtnRef.current?.getBoundingClientRect().bottom ?? 0) + 4,
+                      left: subStatBtnRef.current?.getBoundingClientRect().left ?? 0,
+                    }}
+                  >
+                    {availableSubStatKeys.map((key) => (
+                      <label key={key} className="substat-dropdown-item">
+                        <input
+                          type="checkbox"
+                          className="ctrl-checkbox"
+                          checked={filters.filterSubStats.includes(key)}
+                          onChange={(e) => filters.toggleSubStat(key, e.target.checked)}
+                        />
+                        {t.stats[key] ?? STAT_NAMES[key]}
+                      </label>
+                    ))}
+                  </div>,
+                  document.body,
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* グループC: 表示設定 */}
+        <div className="ctrl-section">
+          <div className="ctrl-section-label">{t.controls.groupDisplay}</div>
+          <div className="ctrl-section-body">
+            {/* サブステソート */}
+            <div className="ctrl-group">
+              <label className="ctrl-label">{t.controls.substatSort}</label>
+              <select
+                className="ctrl-select"
+                value={subStatSort}
+                onChange={(e) => setSubStatSort(e.target.value as StatKey | '')}
+              >
+                <option value="">{t.controls.byScore}</option>
+                {ALL_SUBSTAT_KEYS.map((key) => (
+                  <option key={key} value={key}>
+                    {t.stats[key] ?? STAT_NAMES[key]}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* 再構築種別 */}
+            <div className="ctrl-group">
+              <label className="ctrl-label">{t.controls.reconstruction}</label>
+              <select
+                className="ctrl-select"
+                value={reconType}
+                onChange={(e) => setReconType(e.target.value as ReconstructionType)}
+              >
+                {RECON_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* 再構築成功率ソート */}
+            <div className="ctrl-group">
+              <div className="ctrl-label">&nbsp;</div>
+              <label className="ctrl-label-toggle">
                 <input
                   type="checkbox"
                   className="ctrl-checkbox"
-                  checked={filters.filterSubStats.includes(key)}
-                  onChange={(e) => filters.toggleSubStat(key, e.target.checked)}
+                  checked={reconSort}
+                  onChange={(e) => setReconSort(e.target.checked)}
                 />
-                {t.stats[key] ?? STAT_NAMES[key]}
+                {t.controls.byOdds}
               </label>
-            ))}
-          </div>,
-          document.body,
-        )}
+            </div>
+          </div>
+        </div>
       </div>
 
-      {/* サブステソート */}
-      <div className="ctrl-group">
-        <label className="ctrl-label">{t.controls.substatSort}</label>
-        <select
-          className="ctrl-select"
-          value={subStatSort}
-          onChange={(e) => setSubStatSort(e.target.value as StatKey | '')}
-        >
-          <option value="">{t.controls.byScore}</option>
-          {ALL_SUBSTAT_KEYS.map((key) => (
-            <option key={key} value={key}>
-              {t.stats[key] ?? STAT_NAMES[key]}
-            </option>
+      {/* アクティブフィルターチップ */}
+      {hasFilter && (
+        <div className="ctrl-filter-chips">
+          {filterChips.map((chip, i) => (
+            <button
+              key={i}
+              type="button"
+              className="ctrl-filter-chip"
+              onClick={chip.onRemove}
+            >
+              {chip.label}
+              <span className="ctrl-chip-close" aria-hidden="true">×</span>
+            </button>
           ))}
-        </select>
-      </div>
-
-      {/* 再構築種別 */}
-      <div className="ctrl-group">
-        <label className="ctrl-label">{t.controls.reconstruction}</label>
-        <select
-          className="ctrl-select"
-          value={reconType}
-          onChange={(e) => setReconType(e.target.value as ReconstructionType)}
-        >
-          {RECON_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>{opt.label}</option>
-          ))}
-        </select>
-      </div>
-
-      {/* 再構築成功率ソート */}
-      <div className="ctrl-group">
-        <label className="ctrl-label-toggle">
-          <input
-            type="checkbox"
-            className="ctrl-checkbox"
-            checked={reconSort}
-            onChange={(e) => setReconSort(e.target.checked)}
-          />
-          {t.controls.byOdds}
-        </label>
-      </div>
-
-      {/* フィルタクリア */}
-      <div className="ctrl-group ctrl-end">
-        <button
-          className="ctrl-btn ctrl-clear"
-          disabled={!hasActiveFilter(
-            filters.filterSets,
-            filters.filterSlot,
-            filters.filterMainStat,
-            filters.filterSubStats,
-            filters.filterInitialOp,
-          )}
-          onClick={filters.resetFilters}
-        >
-          {t.controls.filterClear}
-        </button>
-      </div>
+          <button
+            type="button"
+            className="ctrl-btn ctrl-clear"
+            onClick={filters.resetFilters}
+          >
+            {t.controls.filterClear}
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/webapp/src/lib/i18n/en.ts
+++ b/webapp/src/lib/i18n/en.ts
@@ -154,6 +154,10 @@ export const en: Translations = {
     filterClear: 'Clear Filters',
     filterBySet: 'Set',
     filterBySlot: 'Slot',
+    groupScore: 'Score',
+    groupFilter: 'Filters',
+    groupDisplay: 'Display',
+    advancedFilter: 'Advanced',
   },
 
   reconTypes: {

--- a/webapp/src/lib/i18n/ja.ts
+++ b/webapp/src/lib/i18n/ja.ts
@@ -94,6 +94,10 @@ export const ja: Translations = {
     filterClear: 'フィルタをクリア',
     filterBySet: 'セット',
     filterBySlot: '部位',
+    groupScore: 'スコア設定',
+    groupFilter: 'フィルター',
+    groupDisplay: '表示設定',
+    advancedFilter: '詳細フィルター',
   },
 
   reconTypes: {

--- a/webapp/src/lib/i18n/types.ts
+++ b/webapp/src/lib/i18n/types.ts
@@ -54,6 +54,10 @@ export interface Translations {
     filterClear: string
     filterBySet: string
     filterBySlot: string
+    groupScore: string
+    groupFilter: string
+    groupDisplay: string
+    advancedFilter: string
   }
 
   reconTypes: Record<'normal' | 'advanced' | 'absolute', string>


### PR DESCRIPTION
Issue #271 の実装。

## 変更内容

- コントロールバーを3グループに分類（スコア設定/フィルター/表示設定）
- 詳細フィルターの折りたたみパネル追加
- アクティブフィルターのピル型チップ表示（×で個別削除）

Closes #271

Generated with [Claude Code](https://claude.ai/code)