### PR TITLE
docs: skill-creatorスキルの言語を日本語に変更

### DIFF
--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -1,109 +1,109 @@
 ---
 name: skill-creator
-description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, update or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
+description: 新しいスキルの作成、既存スキルの修正・改善、スキルのパフォーマンス計測を行うスキル。スキルをゼロから作成したい・既存スキルを最適化したい・evalでテストしたい・ベンチマーク分析を行いたい・説明文のトリガー精度を最適化したい場合に使用する。
 ---
 
-# Skill Creator
+# スキルクリエーター
 
-A skill for creating new skills and iteratively improving them.
+新しいスキルを作成し、反復的に改善するためのスキル。
 
-The core loop:
-1. Understand what the skill should do
-2. Write or edit a skill draft
-3. Run test cases via parallel subagents (skill vs. baseline)
-4. Help the user evaluate results qualitatively and quantitatively
-5. Improve the skill based on feedback
-6. Repeat until satisfied
-7. Optionally: optimize the description for better triggering
+コアループ:
+1. スキルが何をすべきか理解する
+2. スキルの草案を書くまたは編集する
+3. 並列サブエージェントでテストケースを実行する（スキルあり vs ベースライン）
+4. 定性的・定量的に結果を評価する
+5. フィードバックに基づきスキルを改善する
+6. 満足するまで繰り返す
+7. オプション: トリガー精度向上のための説明文最適化
 
-Jump in wherever the user is. If they have an existing skill already, go straight to step 3. If they say "just vibe with me," skip the formal eval loop and iterate directly.
+ユーザーがいる段階から参加する。既存のスキルがあればステップ3から始める。「直感的に進めよう」と言われたら、フォーマルなevalループをスキップして直接イテレーションする。
 
-**Context efficiency note**: Subagents run in isolated (forked) contexts and don't accumulate tokens in the main conversation. Use them freely for eval runs and grading — this keeps the main context focused on planning and writing the skill itself.
+**コンテキスト効率の注意**: サブエージェントは独立した（フォーク）コンテキストで実行され、メイン会話のトークンを消費しない。evalの実行やグレーディングに自由に使用することで、メインコンテキストを計画とスキル執筆に集中させる。
 
-## Communicating with the user
+## ユーザーとのコミュニケーション
 
-People using this skill range from beginners to experienced engineers. Read context cues carefully:
-- "evaluation" and "benchmark" are OK
-- "JSON" and "assertion" need context cues before using without explanation
+このスキルを使用する人は、初心者から経験豊富なエンジニアまで幅広い。文脈の手がかりを注意深く読む:
+- 「評価」「ベンチマーク」はそのまま使用して良い
+- 「JSON」「アサーション」は説明なしに使う場合は文脈を確認する
 
-Brief definitions are welcome when in doubt.
+疑わしい場合は簡単な定義を添える。
 
 ---
 
-## Creating a skill
+## スキルの作成
 
-### Capture Intent
+### 意図の把握
 
-Check the conversation history first — tools used, corrections made, and input/output patterns may already tell you a lot.
+まず会話履歴を確認する — 使用ツール、修正点、入出力パターンが多くを語ってくれる。
 
-1. What should this skill enable Claude to do?
-2. When should this skill trigger? (what user phrases/contexts)
-3. What's the expected output format?
-4. Should we set up test cases? Skills with objectively verifiable outputs (file transforms, code generation, fixed workflows) benefit from them. Subjective skills (writing style, art) often don't. Suggest a default, let the user decide.
+1. このスキルはClaudeに何をできるようにするか？
+2. いつこのスキルをトリガーするか？（どんなユーザーフレーズ・コンテキスト）
+3. 期待する出力フォーマットは何か？
+4. テストケースを設定するか？客観的に検証可能な出力（ファイル変換、コード生成、固定ワークフロー）を持つスキルは有益。主観的なスキル（文体、アート）は多くの場合不要。デフォルトを提案し、ユーザーに決定してもらう。
 
-### Interview and Research
+### インタビューとリサーチ
 
-Ask about edge cases, example files, success criteria, and dependencies. Don't write test prompts until this is settled.
+エッジケース、サンプルファイル、成功基準、依存関係について確認する。テストプロンプトはこれが確定するまで書かない。
 
-Check available MCPs — if useful for research, spawn parallel subagents to research in the background while you continue interviewing the user.
+利用可能なMCPを確認する — リサーチに有用なら、インタビュー中にバックグラウンドで並列サブエージェントをリサーチに使う。
 
-### Write the SKILL.md
+### SKILL.mdの作成
 
-Components to fill in:
+記入すべき要素:
 
-- **name**: lowercase, hyphens, max 64 chars
-- **description**: what it does + when to use it. This is the primary trigger mechanism. Make it a bit "pushy" — Claude tends to undertrigger. Instead of "helps with dashboards," write "Use this whenever the user mentions dashboards, data visualization, or internal metrics, even if they don't say 'dashboard'."
-- **the rest of the skill**
+- **name**: 小文字、ハイフン、最大64文字
+- **description**: 機能と使用タイミング。これが主要なトリガーメカニズム。少し「積極的」に書く — Claudeはトリガーが少なすぎる傾向がある。「ダッシュボードに役立つ」ではなく「ユーザーがダッシュボード、データ可視化、内部メトリクスに言及するときは常に使用する」と書く。
+- **スキルの残りの部分**
 
-#### Anatomy of a Skill
+#### スキルの構造
 
 ```
 skill-name/
-├── SKILL.md (required, <500 lines)
-│   ├── YAML frontmatter (name, description required)
-│   └── Markdown instructions
-└── Bundled Resources (optional)
-    ├── scripts/    - Executable code (runs without loading into context)
-    ├── references/ - Docs loaded as needed (zero cost until accessed)
-    └── assets/     - Templates, icons, fonts
+├── SKILL.md (必須、500行以内)
+│   ├── YAMLフロントマター (name, description必須)
+│   └── Markdownの指示
+└── バンドルリソース (オプション)
+    ├── scripts/    - 実行可能コード（コンテキストに読み込まずに実行）
+    ├── references/ - 必要時に読み込まれるドキュメント（アクセスまでコストゼロ）
+    └── assets/     - テンプレート、アイコン、フォント
 ```
 
-#### Progressive Disclosure
+#### プログレッシブディスクロージャー
 
-Three loading levels — keep this in mind as the skill grows:
-1. **Metadata** (name + description) — always in context
-2. **SKILL.md body** — loaded when skill triggers (keep under 500 lines)
-3. **Bundled resources** — loaded or executed only as needed, no context cost until accessed
+3つの読み込みレベル — スキルが大きくなったら考慮する:
+1. **メタデータ** (name + description) — 常にコンテキストに存在
+2. **SKILL.mdボディ** — スキルトリガー時に読み込み（500行以内に収める）
+3. **バンドルリソース** — 必要時のみ読み込み・実行、アクセスまでコストなし
 
-When SKILL.md grows large, move detailed content to `references/` and add clear pointers. When a skill covers multiple domains, organize by domain so only the relevant file gets loaded:
+SKILL.mdが大きくなったら、詳細なコンテンツを`references/`に移動して明確なポインタを追加する。スキルが複数のドメインをカバーする場合は、関連ファイルのみが読み込まれるようにドメイン別に整理する:
 
 ```
 bigquery-skill/
-├── SKILL.md (overview + navigation)
+├── SKILL.md (概要とナビゲーション)
 └── references/
     ├── finance.md
     ├── sales.md
     └── product.md
 ```
 
-Keep references 1 level deep — nested references cause partial reads and missed information.
+参照は1レベルの深さに保つ — ネストされた参照は部分的な読み込みや情報の見落としを引き起こす。
 
-#### Writing Style
+#### 文体
 
-- Use imperative form
-- Explain *why*, not just *what* — LLMs reason better with purpose than rigid rules
-- Prefer one clear approach over multiple options
-- Start with a draft, read it fresh, improve it
+- 命令形を使用する
+- *なぜ*を説明する、*何を*だけでなく — LLMは硬直したルールよりも目的で推論する
+- 複数の選択肢ではなく、一つの明確なアプローチを優先する
+- 草案を書き、新鮮な目で読み返し、改善する
 
-#### Principle of Lack of Surprise
+#### 予測可能性の原則
 
-Skills must not contain malware, exploit code, or deceptive content. A skill's behavior should match exactly what its description promises.
+スキルにマルウェア、エクスプロイトコード、または欺瞞的なコンテンツを含めてはならない。スキルの動作は説明が約束する内容と完全に一致しなければならない。
 
-### Test Cases
+### テストケース
 
-Come up with 2-3 realistic test prompts — what a real user would actually type. Share them: "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
+現実的なテストプロンプトを2〜3個考える — 実際のユーザーが入力するもの。共有する: 「試したいテストケースをいくつか用意しました。これで良いですか、追加しますか？」その後実行する。
 
-Save test cases to `evals/evals.json`:
+テストケースを`evals/evals.json`に保存する:
 
 ```json
 {
@@ -111,96 +111,96 @@ Save test cases to `evals/evals.json`:
   "evals": [
     {
       "id": 1,
-      "prompt": "User's task prompt",
-      "expected_output": "Description of expected result",
+      "prompt": "ユーザーのタスクプロンプト",
+      "expected_output": "期待される結果の説明",
       "files": []
     }
   ]
 }
 ```
 
-See `references/schemas.md` for the full schema including the `assertions` field.
+`assertions`フィールドを含む完全なスキーマは`references/schemas.md`を参照。
 
 ---
 
-## Running and evaluating test cases
+## テストケースの実行と評価
 
-Read `references/running-evals.md` for the complete step-by-step process (Steps 1–5).
+完全なステップバイステップのプロセス（ステップ1〜5）は`references/running-evals.md`を参照。
 
-**Overview:**
-1. Spawn all runs (with-skill + baseline) as parallel subagents in the same turn — subagents run in forked contexts, keeping main conversation lean
-2. While runs are in progress, draft quantitative assertions
-3. Capture timing data from each subagent completion notification (only opportunity to get it)
-4. Grade, aggregate into benchmark, launch eval viewer
-5. Read user feedback from `feedback.json`
+**概要:**
+1. すべての実行（スキルあり + ベースライン）を同じターンで並列サブエージェントとして起動 — サブエージェントはフォークされたコンテキストで実行され、メイン会話をスリムに保つ
+2. 実行中に定量的アサーションを草案する
+3. 各サブエージェント完了通知からタイミングデータを取得（取得できる唯一の機会）
+4. グレーディング、ベンチマーク集計、evalビューアー起動
+5. `feedback.json`からユーザーフィードバックを読む
 
-Do NOT stop partway through — this is one continuous sequence.
-
----
-
-## Improving the skill
-
-Read `references/improving-skill.md` for detailed guidance.
-
-Key principles:
-- **Generalize** from examples — don't overfit to specific test cases
-- **Keep it lean** — remove instructions that aren't pulling their weight
-- **Explain the why** — reasoning beats rigid rules
-- **Bundle repeated work** — if subagents independently write the same helper script across test cases, bundle it in `scripts/`
-
-After improving, rerun all test cases into a new `iteration-N+1/` directory and repeat.
+途中で止めない — これは一連の連続したシーケンス。
 
 ---
 
-## Description Optimization
+## スキルの改善
 
-Read `references/description-optimization.md` for the full workflow.
+詳細なガイダンスは`references/improving-skill.md`を参照。
 
-**Overview:**
-1. Generate 20 eval queries (mix of should-trigger and should-not-trigger)
-2. Review with user via `assets/eval_review.html`
-3. Run `scripts/run_loop.py` in background to iteratively optimize
-4. Apply `best_description` to SKILL.md frontmatter
+主要な原則:
+- **一般化** — 特定のテストケースに過適合しない
+- **スリムに保つ** — 効果のない指示を削除する
+- **理由を説明する** — 推論は硬直したルールに勝る
+- **繰り返し作業をバンドルする** — サブエージェントが独立して同じヘルパースクリプトを書いていたら`scripts/`にバンドルする
 
-Do this after the skill itself is in good shape — not before.
-
----
-
-## Platform-specific notes
-
-Read `references/platform-specific.md` for Claude.ai and Cowork adaptations.
-
-Short version:
-- **Claude Code**: Full workflow (subagents, browser viewer, description optimization)
-- **Claude.ai**: No subagents → run tests inline, skip baselines and benchmarking
-- **Cowork**: Use `--static` for viewer (no browser), feedback downloads as `feedback.json`
+改善後、すべてのテストケースを新しい`iteration-N+1/`ディレクトリに再実行して繰り返す。
 
 ---
 
-## Reference files
+## 説明文の最適化
 
-| File | When to read |
+完全なワークフローは`references/description-optimization.md`を参照。
+
+**概要:**
+1. 20件のevalクエリを生成（トリガーすべき・すべきでないを混在）
+2. `assets/eval_review.html`でユーザーと確認
+3. `scripts/run_loop.py`をバックグラウンドで実行して反復最適化
+4. `best_description`をSKILL.mdフロントマターに適用
+
+スキル自体が良好な状態になった後に行う — それ以前は不可。
+
+---
+
+## プラットフォーム固有のメモ
+
+Claude.aiとCoworkの適応については`references/platform-specific.md`を参照。
+
+短い要約:
+- **Claude Code**: 完全なワークフロー（サブエージェント、ブラウザビューアー、説明文最適化）
+- **Claude.ai**: サブエージェントなし → インラインでテスト実行、ベースラインとベンチマークをスキップ
+- **Cowork**: ビューアーには`--static`を使用（ブラウザなし）、フィードバックは`feedback.json`としてダウンロード
+
+---
+
+## リファレンスファイル
+
+| ファイル | 読むタイミング |
 |------|--------------|
-| `references/running-evals.md` | When starting eval runs (Steps 1–5) |
-| `references/improving-skill.md` | When iterating on feedback |
-| `references/description-optimization.md` | When optimizing trigger description |
-| `references/platform-specific.md` | When on Claude.ai or Cowork |
-| `references/schemas.md` | When checking JSON schemas for evals/grading |
-| `agents/grader.md` | When spawning grader subagent |
-| `agents/comparator.md` | When doing blind A/B comparison |
-| `agents/analyzer.md` | When analyzing benchmark results |
+| `references/running-evals.md` | eval実行を開始するとき（ステップ1〜5） |
+| `references/improving-skill.md` | フィードバックに基づいてイテレーションするとき |
+| `references/description-optimization.md` | トリガー説明文を最適化するとき |
+| `references/platform-specific.md` | Claude.aiまたはCoworkを使用するとき |
+| `references/schemas.md` | evals/グレーディングのJSONスキーマを確認するとき |
+| `agents/grader.md` | グレーダーサブエージェントを起動するとき |
+| `agents/comparator.md` | ブラインドA/B比較を行うとき |
+| `agents/analyzer.md` | ベンチマーク結果を分析するとき |
 
 ---
 
-## The loop (summary)
+## ループ（まとめ）
 
-1. Understand the skill
-2. Draft or edit SKILL.md
-3. Run tests → `references/running-evals.md`
-4. User reviews in eval viewer
-5. Improve → `references/improving-skill.md`
-6. Repeat until satisfied
-7. Optimize description → `references/description-optimization.md`
-8. Package (if `present_files` is available): `python -m scripts.package_skill <skill-path>`
+1. スキルを理解する
+2. SKILL.mdを草案または編集する
+3. テスト実行 → `references/running-evals.md`
+4. ユーザーがevalビューアーで確認
+5. 改善 → `references/improving-skill.md`
+6. 満足するまで繰り返す
+7. 説明文の最適化 → `references/description-optimization.md`
+8. パッケージ化（`present_files`が利用可能な場合）: `python -m scripts.package_skill <skill-path>`
 
-Add these as TodoList items. Good luck!
+これらをTodoListアイテムとして追加する。頑張って！

--- a/.claude/skills/skill-creator/agents/analyzer.md
+++ b/.claude/skills/skill-creator/agents/analyzer.md
@@ -1,96 +1,96 @@
-# Post-hoc Analyzer Agent
+# ポストホック分析エージェント
 
-Analyze blind comparison results to understand WHY the winner won and generate improvement suggestions.
+ブラインド比較結果を分析し、勝者が勝った理由を理解して改善提案を生成する。
 
-## Role
+## 役割
 
-After the blind comparator determines a winner, the Post-hoc Analyzer "unblids" the results by examining the skills and transcripts. The goal is to extract actionable insights: what made the winner better, and how can the loser be improved?
+ブラインドコンパレーターが勝者を決定した後、ポストホック分析エージェントはスキルとトランスクリプトを確認することで結果を「ブラインド解除」する。目的は実行可能なインサイトを抽出すること: 勝者を優れたものにした要因と、敗者をどう改善できるか。
 
-## Inputs
+## 入力
 
-You receive these parameters in your prompt:
+プロンプトで以下のパラメーターを受け取る:
 
-- **winner**: "A" or "B" (from blind comparison)
-- **winner_skill_path**: Path to the skill that produced the winning output
-- **winner_transcript_path**: Path to the execution transcript for the winner
-- **loser_skill_path**: Path to the skill that produced the losing output
-- **loser_transcript_path**: Path to the execution transcript for the loser
-- **comparison_result_path**: Path to the blind comparator's output JSON
-- **output_path**: Where to save the analysis results
+- **winner**: "A" または "B"（ブラインド比較から）
+- **winner_skill_path**: 勝者の出力を生成したスキルへのパス
+- **winner_transcript_path**: 勝者の実行トランスクリプトへのパス
+- **loser_skill_path**: 敗者の出力を生成したスキルへのパス
+- **loser_transcript_path**: 敗者の実行トランスクリプトへのパス
+- **comparison_result_path**: ブラインドコンパレーターの出力JSONへのパス
+- **output_path**: 分析結果の保存先
 
-## Process
+## プロセス
 
-### Step 1: Read Comparison Result
+### ステップ1: 比較結果を読む
 
-1. Read the blind comparator's output at comparison_result_path
-2. Note the winning side (A or B), the reasoning, and any scores
-3. Understand what the comparator valued in the winning output
+1. comparison_result_pathにあるブラインドコンパレーターの出力を読む
+2. 勝者側（AまたはB）、推論、スコアを確認する
+3. コンパレーターが勝者の出力で何を評価したか理解する
 
-### Step 2: Read Both Skills
+### ステップ2: 両スキルを読む
 
-1. Read the winner skill's SKILL.md and key referenced files
-2. Read the loser skill's SKILL.md and key referenced files
-3. Identify structural differences:
-   - Instructions clarity and specificity
-   - Script/tool usage patterns
-   - Example coverage
-   - Edge case handling
+1. 勝者スキルのSKILL.mdと参照された主要ファイルを読む
+2. 敗者スキルのSKILL.mdと参照された主要ファイルを読む
+3. 構造的な違いを特定する:
+   - 指示の明確さと具体性
+   - スクリプト・ツールの使用パターン
+   - サンプルのカバレッジ
+   - エッジケースの処理
 
-### Step 3: Read Both Transcripts
+### ステップ3: 両トランスクリプトを読む
 
-1. Read the winner's transcript
-2. Read the loser's transcript
-3. Compare execution patterns:
-   - How closely did each follow their skill's instructions?
-   - What tools were used differently?
-   - Where did the loser diverge from optimal behavior?
-   - Did either encounter errors or make recovery attempts?
+1. 勝者のトランスクリプトを読む
+2. 敗者のトランスクリプトを読む
+3. 実行パターンを比較する:
+   - 各エージェントはスキルの指示にどれほど忠実に従ったか？
+   - ツールの使い方はどう違ったか？
+   - 敗者はどこで最適な行動から外れたか？
+   - どちらかがエラーを経験したり回復を試みたりしたか？
 
-### Step 4: Analyze Instruction Following
+### ステップ4: 指示遵守の分析
 
-For each transcript, evaluate:
-- Did the agent follow the skill's explicit instructions?
-- Did the agent use the skill's provided tools/scripts?
-- Were there missed opportunities to leverage skill content?
-- Did the agent add unnecessary steps not in the skill?
+各トランスクリプトについて評価する:
+- エージェントはスキルの明示的な指示に従ったか？
+- エージェントはスキルが提供するツール・スクリプトを使用したか？
+- スキルの内容を活用する機会を逃したか？
+- スキルにない不要なステップを追加したか？
 
-Score instruction following 1-10 and note specific issues.
+指示遵守を1〜10でスコアし、具体的な問題を記録する。
 
-### Step 5: Identify Winner Strengths
+### ステップ5: 勝者の強みを特定する
 
-Determine what made the winner better:
-- Clearer instructions that led to better behavior?
-- Better scripts/tools that produced better output?
-- More comprehensive examples that guided edge cases?
-- Better error handling guidance?
+勝者を優れたものにした要因を特定する:
+- より良い動作につながった明確な指示？
+- より良い出力を生成したスクリプト・ツール？
+- エッジケースをガイドした包括的なサンプル？
+- より良いエラー処理ガイダンス？
 
-Be specific. Quote from skills/transcripts where relevant.
+具体的に。スキル・トランスクリプトから引用する。
 
-### Step 6: Identify Loser Weaknesses
+### ステップ6: 敗者の弱点を特定する
 
-Determine what held the loser back:
-- Ambiguous instructions that led to suboptimal choices?
-- Missing tools/scripts that forced workarounds?
-- Gaps in edge case coverage?
-- Poor error handling that caused failures?
+敗者を妨げた要因を特定する:
+- 最適でない選択につながった曖昧な指示？
+- 回避策を強いた不足ツール・スクリプト？
+- エッジケースカバレッジのギャップ？
+- 失敗を引き起こした不十分なエラー処理？
 
-### Step 7: Generate Improvement Suggestions
+### ステップ7: 改善提案を生成する
 
-Based on the analysis, produce actionable suggestions for improving the loser skill:
-- Specific instruction changes to make
-- Tools/scripts to add or modify
-- Examples to include
-- Edge cases to address
+分析に基づき、敗者スキルを改善するための実行可能な提案を作成する:
+- 変更すべき具体的な指示
+- 追加・修正すべきツール・スクリプト
+- 含めるべきサンプル
+- 対応すべきエッジケース
 
-Prioritize by impact. Focus on changes that would have changed the outcome.
+影響度で優先順位をつける。結果を変えたであろう変更に注目する。
 
-### Step 8: Write Analysis Results
+### ステップ8: 分析結果を書く
 
-Save structured analysis to `{output_path}`.
+`{output_path}`に構造化した分析を保存する。
 
-## Output Format
+## 出力フォーマット
 
-Write a JSON file with this structure:
+以下の構造でJSONファイルを書く:
 
 ```json
 {
@@ -98,31 +98,31 @@ Write a JSON file with this structure:
     "winner": "A",
     "winner_skill": "path/to/winner/skill",
     "loser_skill": "path/to/loser/skill",
-    "comparator_reasoning": "Brief summary of why comparator chose winner"
+    "comparator_reasoning": "コンパレーターが勝者を選んだ理由の概要"
   },
   "winner_strengths": [
-    "Clear step-by-step instructions for handling multi-page documents",
-    "Included validation script that caught formatting errors",
-    "Explicit guidance on fallback behavior when OCR fails"
+    "複数ページドキュメント処理のための明確なステップバイステップの指示",
+    "フォーマットエラーを検出した検証スクリプトを含む",
+    "OCR失敗時のフォールバック動作に関する明示的なガイダンス"
   ],
   "loser_weaknesses": [
-    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
-    "No script for validation, agent had to improvise and made errors",
-    "No guidance on OCR failure, agent gave up instead of trying alternatives"
+    "「適切にドキュメントを処理する」という曖昧な指示が一貫性のない動作につながった",
+    "検証スクリプトがなく、エージェントが即興してエラーを犯した",
+    "OCR失敗のガイダンスがなく、エージェントが代替手段を試みずに諦めた"
   ],
   "instruction_following": {
     "winner": {
       "score": 9,
       "issues": [
-        "Minor: skipped optional logging step"
+        "軽微: オプションのログ記録ステップをスキップした"
       ]
     },
     "loser": {
       "score": 6,
       "issues": [
-        "Did not use the skill's formatting template",
-        "Invented own approach instead of following step 3",
-        "Missed the 'always validate output' instruction"
+        "スキルのフォーマットテンプレートを使用しなかった",
+        "ステップ3を無視して独自のアプローチを考案した",
+        "「常に出力を検証する」という指示を見逃した"
       ]
     }
   },
@@ -130,145 +130,145 @@ Write a JSON file with this structure:
     {
       "priority": "high",
       "category": "instructions",
-      "suggestion": "Replace 'process the document appropriately' with explicit steps: 1) Extract text, 2) Identify sections, 3) Format per template",
-      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+      "suggestion": "「適切にドキュメントを処理する」を明示的なステップに置き換える: 1) テキストを抽出、2) セクションを識別、3) テンプレートに沿ってフォーマット",
+      "expected_impact": "一貫性のない動作を引き起こした曖昧さを排除できる"
     },
     {
       "priority": "high",
       "category": "tools",
-      "suggestion": "Add validate_output.py script similar to winner skill's validation approach",
-      "expected_impact": "Would catch formatting errors before final output"
+      "suggestion": "勝者スキルの検証アプローチに似たvalidate_output.pyスクリプトを追加する",
+      "expected_impact": "最終出力前にフォーマットエラーを検出できる"
     },
     {
       "priority": "medium",
       "category": "error_handling",
-      "suggestion": "Add fallback instructions: 'If OCR fails, try: 1) different resolution, 2) image preprocessing, 3) manual extraction'",
-      "expected_impact": "Would prevent early failure on difficult documents"
+      "suggestion": "フォールバック指示を追加する: 「OCRが失敗した場合: 1) 解像度を変更、2) 画像前処理、3) 手動抽出」",
+      "expected_impact": "難しいドキュメントで早期失敗を防げる"
     }
   ],
   "transcript_insights": {
-    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script -> Fixed 2 issues -> Produced output",
-    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods -> No validation -> Output had errors"
+    "winner_execution_pattern": "スキル読み込み -> 5ステップのプロセスに従う -> 検証スクリプト使用 -> 2つの問題を修正 -> 出力生成",
+    "loser_execution_pattern": "スキル読み込み -> アプローチが不明確 -> 3つの異なる方法を試行 -> 検証なし -> 出力にエラー"
   }
 }
 ```
 
-## Guidelines
+## ガイドライン
 
-- **Be specific**: Quote from skills and transcripts, don't just say "instructions were unclear"
-- **Be actionable**: Suggestions should be concrete changes, not vague advice
-- **Focus on skill improvements**: The goal is to improve the losing skill, not critique the agent
-- **Prioritize by impact**: Which changes would most likely have changed the outcome?
-- **Consider causation**: Did the skill weakness actually cause the worse output, or is it incidental?
-- **Stay objective**: Analyze what happened, don't editorialize
-- **Think about generalization**: Would this improvement help on other evals too?
+- **具体的に**: スキルとトランスクリプトから引用する。「指示が不明確だった」とだけ言わない
+- **実行可能に**: 提案は具体的な変更であり、曖昧なアドバイスではない
+- **スキル改善に焦点を当てる**: 目的は敗者スキルを改善することで、エージェントを批判することではない
+- **影響度で優先順位をつける**: どの変更が結果を変える可能性が最も高いか？
+- **因果関係を考慮する**: スキルの弱点が実際に悪い出力を引き起こしたか、それとも偶発的か？
+- **客観的に**: 何が起きたかを分析し、論評しない
+- **一般化について考える**: この改善は他のevalでも役立つか？
 
-## Categories for Suggestions
+## 提案のカテゴリー
 
-Use these categories to organize improvement suggestions:
+改善提案を整理するためのカテゴリー:
 
-| Category | Description |
+| カテゴリー | 説明 |
 |----------|-------------|
-| `instructions` | Changes to the skill's prose instructions |
-| `tools` | Scripts, templates, or utilities to add/modify |
-| `examples` | Example inputs/outputs to include |
-| `error_handling` | Guidance for handling failures |
-| `structure` | Reorganization of skill content |
-| `references` | External docs or resources to add |
+| `instructions` | スキルの散文指示への変更 |
+| `tools` | 追加・修正するスクリプト、テンプレート、ユーティリティ |
+| `examples` | 含めるべきサンプル入出力 |
+| `error_handling` | 失敗処理のガイダンス |
+| `structure` | スキルコンテンツの再編成 |
+| `references` | 追加すべき外部ドキュメントやリソース |
 
-## Priority Levels
+## 優先度レベル
 
-- **high**: Would likely change the outcome of this comparison
-- **medium**: Would improve quality but may not change win/loss
-- **low**: Nice to have, marginal improvement
+- **high**: この比較の結果を変えた可能性が高い
+- **medium**: 品質を向上させるが、勝敗を変えない可能性がある
+- **low**: あると良い、改善は限定的
 
 ---
 
-# Analyzing Benchmark Results
+# ベンチマーク結果の分析
 
-When analyzing benchmark results, the analyzer's purpose is to **surface patterns and anomalies** across multiple runs, not suggest skill improvements.
+ベンチマーク結果を分析する際、アナライザーの目的は複数の実行にわたる**パターンと異常を浮き彫りにすること**であり、スキルの改善提案をすることではない。
 
-## Role
+## 役割
 
-Review all benchmark run results and generate freeform notes that help the user understand skill performance. Focus on patterns that wouldn't be visible from aggregate metrics alone.
+すべてのベンチマーク実行結果を確認し、ユーザーがスキルのパフォーマンスを理解するのに役立つ自由形式のメモを生成する。集計メトリクスだけでは見えないパターンに注目する。
 
-## Inputs
+## 入力
 
-You receive these parameters in your prompt:
+プロンプトで以下のパラメーターを受け取る:
 
-- **benchmark_data_path**: Path to the in-progress benchmark.json with all run results
-- **skill_path**: Path to the skill being benchmarked
-- **output_path**: Where to save the notes (as JSON array of strings)
+- **benchmark_data_path**: すべての実行結果を含む進行中のbenchmark.jsonへのパス
+- **skill_path**: ベンチマーク対象スキルへのパス
+- **output_path**: メモの保存先（JSON配列の文字列として）
 
-## Process
+## プロセス
 
-### Step 1: Read Benchmark Data
+### ステップ1: ベンチマークデータを読む
 
-1. Read the benchmark.json containing all run results
-2. Note the configurations tested (with_skill, without_skill)
-3. Understand the run_summary aggregates already calculated
+1. すべての実行結果を含むbenchmark.jsonを読む
+2. テストされた設定（with_skill、without_skill）を確認する
+3. 既に計算されたrun_summary集計を理解する
 
-### Step 2: Analyze Per-Assertion Patterns
+### ステップ2: アサーション単位のパターンを分析する
 
-For each expectation across all runs:
-- Does it **always pass** in both configurations? (may not differentiate skill value)
-- Does it **always fail** in both configurations? (may be broken or beyond capability)
-- Does it **always pass with skill but fail without**? (skill clearly adds value here)
-- Does it **always fail with skill but pass without**? (skill may be hurting)
-- Is it **highly variable**? (flaky expectation or non-deterministic behavior)
+各evalにわたる各期待値について:
+- 両設定で**常にパス**するか？（スキルの価値を区別しない可能性）
+- 両設定で**常にフェイル**するか？（壊れているか能力の限界の可能性）
+- スキルありで**常にパス、スキルなしでフェイル**するか？（スキルが明確に価値を追加）
+- スキルありで**常にフェイル、スキルなしでパス**するか？（スキルが悪影響の可能性）
+- **高度に変動的**か？（不安定なアサーションか非決定的な動作）
 
-### Step 3: Analyze Cross-Eval Patterns
+### ステップ3: eval横断パターンを分析する
 
-Look for patterns across evals:
-- Are certain eval types consistently harder/easier?
-- Do some evals show high variance while others are stable?
-- Are there surprising results that contradict expectations?
+eval全体のパターンを探す:
+- 特定のevalタイプが一貫して難しい・簡単か？
+- 高い分散を示すevalと安定したevalがあるか？
+- 期待に反する驚くべき結果があるか？
 
-### Step 4: Analyze Metrics Patterns
+### ステップ4: メトリクスパターンを分析する
 
-Look at time_seconds, tokens, tool_calls:
-- Does the skill significantly increase execution time?
-- Is there high variance in resource usage?
-- Are there outlier runs that skew the aggregates?
+time_seconds、tokens、tool_callsを確認する:
+- スキルが実行時間を大幅に増加させるか？
+- リソース使用量に高い分散があるか？
+- 集計値を歪める外れ値の実行があるか？
 
-### Step 5: Generate Notes
+### ステップ5: メモを生成する
 
-Write freeform observations as a list of strings. Each note should:
-- State a specific observation
-- Be grounded in the data (not speculation)
-- Help the user understand something the aggregate metrics don't show
+観察を文字列のリストとして自由形式で記述する。各メモは:
+- 具体的な観察を述べる
+- データに基づいている（推測ではない）
+- 集計メトリクスが示さない何かをユーザーが理解するのに役立つ
 
-Examples:
-- "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value"
-- "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure that may be flaky"
-- "Without-skill runs consistently fail on table extraction expectations (0% pass rate)"
-- "Skill adds 13s average execution time but improves pass rate by 50%"
-- "Token usage is 80% higher with skill, primarily due to script output parsing"
-- "All 3 without-skill runs for eval 1 produced empty output"
+例:
+- 「アサーション 'Output is a PDF file' が両設定で100%パス — スキルの価値を区別しない可能性」
+- 「Eval 3が高い分散を示す（50% ± 40%）— 実行2に不安定な可能性のある異常な失敗があった」
+- 「スキルなし実行がテーブル抽出の期待値で一貫して失敗（パス率0%）」
+- 「スキルが平均13秒の実行時間を追加するが、パス率を50%改善する」
+- 「スキルありでトークン使用量が80%高く、主にスクリプト出力の解析によるもの」
+- 「eval 1のスキルなし3回の実行すべてが空の出力を生成した」
 
-### Step 6: Write Notes
+### ステップ6: メモを書く
 
-Save notes to `{output_path}` as a JSON array of strings:
+`{output_path}`にJSON文字列配列としてメモを保存する:
 
 ```json
 [
-  "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
-  "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure",
-  "Without-skill runs consistently fail on table extraction expectations",
-  "Skill adds 13s average execution time but improves pass rate by 50%"
+  "アサーション 'Output is a PDF file' が両設定で100%パス — スキルの価値を区別しない可能性",
+  "Eval 3が高い分散を示す（50% ± 40%）— 実行2に不安定な失敗の可能性",
+  "スキルなし実行がテーブル抽出の期待値で一貫して失敗",
+  "スキルが平均13秒の実行時間を追加するが、パス率を50%改善する"
 ]
 ```
 
-## Guidelines
+## ガイドライン
 
-**DO:**
-- Report what you observe in the data
-- Be specific about which evals, expectations, or runs you're referring to
-- Note patterns that aggregate metrics would hide
-- Provide context that helps interpret the numbers
+**すること:**
+- データで観察したことを報告する
+- 参照しているeval、期待値、実行を具体的に示す
+- 集計メトリクスが隠すパターンに注目する
+- 数値を解釈するための文脈を提供する
 
-**DO NOT:**
-- Suggest improvements to the skill (that's for the improvement step, not benchmarking)
-- Make subjective quality judgments ("the output was good/bad")
-- Speculate about causes without evidence
-- Repeat information already in the run_summary aggregates
+**しないこと:**
+- スキルの改善提案をする（それは改善ステップの役割であり、ベンチマークではない）
+- 主観的な品質判断をする（「出力が良い・悪かった」）
+- 証拠なしに原因を推測する
+- run_summaryの集計に既にある情報を繰り返す

--- a/.claude/skills/skill-creator/agents/comparator.md
+++ b/.claude/skills/skill-creator/agents/comparator.md
@@ -1,101 +1,101 @@
-# Blind Comparator Agent
+# ブラインドコンパレーターエージェント
 
-Compare two outputs WITHOUT knowing which skill produced them.
+どちらのスキルが出力を生成したか知らずに2つの出力を比較する。
 
-## Role
+## 役割
 
-The Blind Comparator judges which output better accomplishes the eval task. You receive two outputs labeled A and B, but you do NOT know which skill produced which. This prevents bias toward a particular skill or approach.
+ブラインドコンパレーターは、どちらの出力がevalタスクをより良く達成しているかを判断する。AとBのラベルが付いた2つの出力を受け取るが、どちらのスキルがどちらを生成したかは知らない。これにより特定のスキルやアプローチへのバイアスを防ぐ。
 
-Your judgment is based purely on output quality and task completion.
+判断は純粋に出力の品質とタスク完了度に基づく。
 
-## Inputs
+## 入力
 
-You receive these parameters in your prompt:
+プロンプトで以下のパラメーターを受け取る:
 
-- **output_a_path**: Path to the first output file or directory
-- **output_b_path**: Path to the second output file or directory
-- **eval_prompt**: The original task/prompt that was executed
-- **expectations**: List of expectations to check (optional - may be empty)
+- **output_a_path**: 最初の出力ファイルまたはディレクトリへのパス
+- **output_b_path**: 2番目の出力ファイルまたはディレクトリへのパス
+- **eval_prompt**: 実行された元のタスク・プロンプト
+- **expectations**: 確認すべき期待値のリスト（オプション — 空の場合もある）
 
-## Process
+## プロセス
 
-### Step 1: Read Both Outputs
+### ステップ1: 両出力を読む
 
-1. Examine output A (file or directory)
-2. Examine output B (file or directory)
-3. Note the type, structure, and content of each
-4. If outputs are directories, examine all relevant files inside
+1. 出力A（ファイルまたはディレクトリ）を確認する
+2. 出力B（ファイルまたはディレクトリ）を確認する
+3. 各出力のタイプ、構造、コンテンツを記録する
+4. 出力がディレクトリの場合、内部のすべての関連ファイルを確認する
 
-### Step 2: Understand the Task
+### ステップ2: タスクを理解する
 
-1. Read the eval_prompt carefully
-2. Identify what the task requires:
-   - What should be produced?
-   - What qualities matter (accuracy, completeness, format)?
-   - What would distinguish a good output from a poor one?
+1. eval_promptを注意深く読む
+2. タスクが要求するものを特定する:
+   - 何を生成すべきか？
+   - どの品質が重要か（正確性、完全性、フォーマット）？
+   - 良い出力と悪い出力を区別するものは何か？
 
-### Step 3: Generate Evaluation Rubric
+### ステップ3: 評価ルーブリックを生成する
 
-Based on the task, generate a rubric with two dimensions:
+タスクに基づき、2つの次元でルーブリックを生成する:
 
-**Content Rubric** (what the output contains):
-| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+**コンテンツルーブリック**（出力に含まれる内容）:
+| 基準 | 1（不良） | 3（許容） | 5（優秀） |
 |-----------|----------|----------------|---------------|
-| Correctness | Major errors | Minor errors | Fully correct |
-| Completeness | Missing key elements | Mostly complete | All elements present |
-| Accuracy | Significant inaccuracies | Minor inaccuracies | Accurate throughout |
+| 正確性 | 重大なエラー | 軽微なエラー | 完全に正確 |
+| 完全性 | 主要な要素が欠落 | ほぼ完全 | すべての要素が存在 |
+| 精度 | 重大な不正確さ | 軽微な不正確さ | 全体を通じて正確 |
 
-**Structure Rubric** (how the output is organized):
-| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+**構造ルーブリック**（出力の組織化方法）:
+| 基準 | 1（不良） | 3（許容） | 5（優秀） |
 |-----------|----------|----------------|---------------|
-| Organization | Disorganized | Reasonably organized | Clear, logical structure |
-| Formatting | Inconsistent/broken | Mostly consistent | Professional, polished |
-| Usability | Difficult to use | Usable with effort | Easy to use |
+| 組織化 | 無秩序 | 合理的に組織化 | 明確で論理的な構造 |
+| フォーマット | 不一致・壊れている | ほぼ一貫 | プロフェッショナルで洗練 |
+| 使いやすさ | 使いにくい | 努力すれば使える | 使いやすい |
 
-Adapt criteria to the specific task. For example:
-- PDF form → "Field alignment", "Text readability", "Data placement"
-- Document → "Section structure", "Heading hierarchy", "Paragraph flow"
-- Data output → "Schema correctness", "Data types", "Completeness"
+特定のタスクに合わせて基準を適応させる。例:
+- PDFフォーム → 「フィールドの配置」「テキストの読みやすさ」「データの配置」
+- ドキュメント → 「セクション構造」「見出し階層」「段落の流れ」
+- データ出力 → 「スキーマの正確性」「データ型」「完全性」
 
-### Step 4: Evaluate Each Output Against the Rubric
+### ステップ4: ルーブリックに対して各出力を評価する
 
-For each output (A and B):
+各出力（AとB）について:
 
-1. **Score each criterion** on the rubric (1-5 scale)
-2. **Calculate dimension totals**: Content score, Structure score
-3. **Calculate overall score**: Average of dimension scores, scaled to 1-10
+1. ルーブリックの**各基準をスコアリング**する（1〜5スケール）
+2. **次元合計を計算**: コンテンツスコア、構造スコア
+3. **総合スコアを計算**: 次元スコアの平均を1〜10にスケール
 
-### Step 5: Check Assertions (if provided)
+### ステップ5: アサーションを確認する（提供された場合）
 
-If expectations are provided:
+期待値が提供されている場合:
 
-1. Check each expectation against output A
-2. Check each expectation against output B
-3. Count pass rates for each output
-4. Use expectation scores as secondary evidence (not the primary decision factor)
+1. 出力Aに対して各期待値を確認する
+2. 出力Bに対して各期待値を確認する
+3. 各出力のパス率を集計する
+4. 期待値スコアを二次的な証拠として使用する（主要な決定要因ではない）
 
-### Step 6: Determine the Winner
+### ステップ6: 勝者を決定する
 
-Compare A and B based on (in priority order):
+（優先順位の順に）AとBを比較する:
 
-1. **Primary**: Overall rubric score (content + structure)
-2. **Secondary**: Assertion pass rates (if applicable)
-3. **Tiebreaker**: If truly equal, declare a TIE
+1. **主要**: 総合ルーブリックスコア（コンテンツ + 構造）
+2. **二次**: アサーションパス率（該当する場合）
+3. **タイブレーカー**: 本当に同等の場合はTIEを宣言する
 
-Be decisive - ties should be rare. One output is usually better, even if marginally.
+決断力を持つ — タイはまれであるべき。わずかな差でも、通常はどちらかが優れている。
 
-### Step 7: Write Comparison Results
+### ステップ7: 比較結果を書く
 
-Save results to a JSON file at the path specified (or `comparison.json` if not specified).
+指定されたパスのJSONファイルに結果を保存する（指定がない場合は`comparison.json`）。
 
-## Output Format
+## 出力フォーマット
 
-Write a JSON file with this structure:
+以下の構造でJSONファイルを書く:
 
 ```json
 {
   "winner": "A",
-  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "reasoning": "出力Aは適切なフォーマットとすべての必須フィールドを含む完全なソリューションを提供する。出力Bはdateフィールドが欠落しており、フォーマットの一貫性に問題がある。",
   "rubric": {
     "A": {
       "content": {
@@ -131,13 +131,13 @@ Write a JSON file with this structure:
   "output_quality": {
     "A": {
       "score": 9,
-      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
-      "weaknesses": ["Minor style inconsistency in header"]
+      "strengths": ["完全なソリューション", "適切なフォーマット", "すべてのフィールドが存在"],
+      "weaknesses": ["ヘッダーのスタイルに軽微な不一致"]
     },
     "B": {
       "score": 5,
-      "strengths": ["Readable output", "Correct basic structure"],
-      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+      "strengths": ["読みやすい出力", "基本構造が正確"],
+      "weaknesses": ["dateフィールドが欠落", "フォーマットの不一致", "データ抽出が部分的"]
     }
   },
   "expectation_results": {
@@ -169,34 +169,34 @@ Write a JSON file with this structure:
 }
 ```
 
-If no expectations were provided, omit the `expectation_results` field entirely.
+期待値が提供されなかった場合は、`expectation_results`フィールドを完全に省略する。
 
-## Field Descriptions
+## フィールドの説明
 
-- **winner**: "A", "B", or "TIE"
-- **reasoning**: Clear explanation of why the winner was chosen (or why it's a tie)
-- **rubric**: Structured rubric evaluation for each output
-  - **content**: Scores for content criteria (correctness, completeness, accuracy)
-  - **structure**: Scores for structure criteria (organization, formatting, usability)
-  - **content_score**: Average of content criteria (1-5)
-  - **structure_score**: Average of structure criteria (1-5)
-  - **overall_score**: Combined score scaled to 1-10
-- **output_quality**: Summary quality assessment
-  - **score**: 1-10 rating (should match rubric overall_score)
-  - **strengths**: List of positive aspects
-  - **weaknesses**: List of issues or shortcomings
-- **expectation_results**: (Only if expectations provided)
-  - **passed**: Number of expectations that passed
-  - **total**: Total number of expectations
-  - **pass_rate**: Fraction passed (0.0 to 1.0)
-  - **details**: Individual expectation results
+- **winner**: "A"、"B"、または "TIE"
+- **reasoning**: 勝者を選んだ理由の明確な説明（またはタイである理由）
+- **rubric**: 各出力に対する構造化されたルーブリック評価
+  - **content**: コンテンツ基準のスコア（正確性、完全性、精度）
+  - **structure**: 構造基準のスコア（組織化、フォーマット、使いやすさ）
+  - **content_score**: コンテンツ基準の平均（1〜5）
+  - **structure_score**: 構造基準の平均（1〜5）
+  - **overall_score**: 1〜10にスケールされた複合スコア
+- **output_quality**: 要約品質評価
+  - **score**: 1〜10の評価（ルーブリックのoverall_scoreと一致すべき）
+  - **strengths**: 長所のリスト
+  - **weaknesses**: 問題や欠点のリスト
+- **expectation_results**: （期待値が提供された場合のみ）
+  - **passed**: パスした期待値の数
+  - **total**: 期待値の総数
+  - **pass_rate**: パス割合（0.0〜1.0）
+  - **details**: 個別の期待値結果
 
-## Guidelines
+## ガイドライン
 
-- **Stay blind**: DO NOT try to infer which skill produced which output. Judge purely on output quality.
-- **Be specific**: Cite specific examples when explaining strengths and weaknesses.
-- **Be decisive**: Choose a winner unless outputs are genuinely equivalent.
-- **Output quality first**: Assertion scores are secondary to overall task completion.
-- **Be objective**: Don't favor outputs based on style preferences; focus on correctness and completeness.
-- **Explain your reasoning**: The reasoning field should make it clear why you chose the winner.
-- **Handle edge cases**: If both outputs fail, pick the one that fails less badly. If both are excellent, pick the one that's marginally better.
+- **ブラインドを維持する**: どちらのスキルがどちらの出力を生成したか推測しようとしない。純粋に出力の品質で判断する。
+- **具体的に**: 強みと弱みを説明するときは具体的な例を挙げる。
+- **決断力を持つ**: 出力が本当に同等でない限り勝者を選ぶ。
+- **出力品質を優先する**: アサーションスコアは総合的なタスク完了度の次に位置する。
+- **客観的に**: スタイルの好みで出力を贔屓しない。正確性と完全性に集中する。
+- **推論を説明する**: reasoningフィールドで勝者を選んだ理由を明確にする。
+- **エッジケースを処理する**: 両出力が失敗した場合、失敗が少ない方を選ぶ。両方が優秀な場合、わずかに優れている方を選ぶ。

--- a/.claude/skills/skill-creator/agents/grader.md
+++ b/.claude/skills/skill-creator/agents/grader.md
@@ -1,129 +1,129 @@
-# Grader Agent
+# グレーダーエージェント
 
-Evaluate expectations against an execution transcript and outputs.
+実行トランスクリプトと出力に対して期待値を評価する。
 
-## Role
+## 役割
 
-The Grader reviews a transcript and output files, then determines whether each expectation passes or fails. Provide clear evidence for each judgment.
+グレーダーはトランスクリプトと出力ファイルを確認し、各期待値がパスするかフェイルするかを判断する。各判断について明確な証拠を提供する。
 
-You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless — it creates false confidence. When you notice an assertion that's trivially satisfied, or an important outcome that no assertion checks, say so.
+2つの役割がある: 出力をグレードすること、そしてeval自体を批評すること。弱いアサーションでのパスは無意味どころか有害 — 誤った自信を生む。些細に満足するアサーションや、重要な結果を確認するアサーションが欠けている場合は指摘する。
 
-## Inputs
+## 入力
 
-You receive these parameters in your prompt:
+プロンプトで以下のパラメーターを受け取る:
 
-- **expectations**: List of expectations to evaluate (strings)
-- **transcript_path**: Path to the execution transcript (markdown file)
-- **outputs_dir**: Directory containing output files from execution
+- **expectations**: 評価すべき期待値のリスト（文字列）
+- **transcript_path**: 実行トランスクリプトへのパス（Markdownファイル）
+- **outputs_dir**: 実行からの出力ファイルを含むディレクトリ
 
-## Process
+## プロセス
 
-### Step 1: Read the Transcript
+### ステップ1: トランスクリプトを読む
 
-1. Read the transcript file completely
-2. Note the eval prompt, execution steps, and final result
-3. Identify any issues or errors documented
+1. トランスクリプトファイルを完全に読む
+2. evalプロンプト、実行ステップ、最終結果を確認する
+3. 記録された問題やエラーを特定する
 
-### Step 2: Examine Output Files
+### ステップ2: 出力ファイルを確認する
 
-1. List files in outputs_dir
-2. Read/examine each file relevant to the expectations. If outputs aren't plain text, use the inspection tools provided in your prompt — don't rely solely on what the transcript says the executor produced.
-3. Note contents, structure, and quality
+1. outputs_dirのファイルをリストアップする
+2. 期待値に関連する各ファイルを読む・確認する。出力がプレーンテキストでない場合、プロンプトで提供された検査ツールを使用する — エグゼキューターがトランスクリプトで述べた内容だけに頼らない。
+3. コンテンツ、構造、品質を記録する
 
-### Step 3: Evaluate Each Assertion
+### ステップ3: 各アサーションを評価する
 
-For each expectation:
+各期待値について:
 
-1. **Search for evidence** in the transcript and outputs
-2. **Determine verdict**:
-   - **PASS**: Clear evidence the expectation is true AND the evidence reflects genuine task completion, not just surface-level compliance
-   - **FAIL**: No evidence, or evidence contradicts the expectation, or the evidence is superficial (e.g., correct filename but empty/wrong content)
-3. **Cite the evidence**: Quote the specific text or describe what you found
+1. トランスクリプトと出力で**証拠を探す**
+2. **判定を決定する**:
+   - **PASS**: 期待値が真であることの明確な証拠があり、かつその証拠が表面的なコンプライアンスではなく真の作業完了を反映している
+   - **FAIL**: 証拠なし、または証拠が期待値と矛盾する、または証拠が表面的（例: 正しいファイル名だが空・誤ったコンテンツ）
+3. **証拠を引用する**: 見つけた具体的なテキストを引用するか説明する
 
-### Step 4: Extract and Verify Claims
+### ステップ4: 主張を抽出して検証する
 
-Beyond the predefined expectations, extract implicit claims from the outputs and verify them:
+定義済みの期待値を超えて、出力から暗黙の主張を抽出して検証する:
 
-1. **Extract claims** from the transcript and outputs:
-   - Factual statements ("The form has 12 fields")
-   - Process claims ("Used pypdf to fill the form")
-   - Quality claims ("All fields were filled correctly")
+1. トランスクリプトと出力から**主張を抽出する**:
+   - 事実の陳述（「フォームには12のフィールドがある」）
+   - プロセスの主張（「pypdfを使用してフォームを記入した」）
+   - 品質の主張（「すべてのフィールドが正しく記入された」）
 
-2. **Verify each claim**:
-   - **Factual claims**: Can be checked against the outputs or external sources
-   - **Process claims**: Can be verified from the transcript
-   - **Quality claims**: Evaluate whether the claim is justified
+2. **各主張を検証する**:
+   - **事実の主張**: 出力または外部ソースと照合して確認できる
+   - **プロセスの主張**: トランスクリプトから検証できる
+   - **品質の主張**: 主張が正当化されているか評価する
 
-3. **Flag unverifiable claims**: Note claims that cannot be verified with available information
+3. **検証不可能な主張にフラグを立てる**: 利用可能な情報では検証できない主張を記録する
 
-This catches issues that predefined expectations might miss.
+これにより定義済みの期待値が見逃す問題を発見する。
 
-### Step 5: Read User Notes
+### ステップ5: ユーザーのメモを読む
 
-If `{outputs_dir}/user_notes.md` exists:
-1. Read it and note any uncertainties or issues flagged by the executor
-2. Include relevant concerns in the grading output
-3. These may reveal problems even when expectations pass
+`{outputs_dir}/user_notes.md`が存在する場合:
+1. 読んでエグゼキューターが指摘した不確実性や問題を記録する
+2. 関連する懸念をグレーディング出力に含める
+3. 期待値がパスしていても問題を明らかにする可能性がある
 
-### Step 6: Critique the Evals
+### ステップ6: evalを批評する
 
-After grading, consider whether the evals themselves could be improved. Only surface suggestions when there's a clear gap.
+グレーディング後、evalそのものが改善できるか考える。明確なギャップがある場合のみ提案を出す。
 
-Good suggestions test meaningful outcomes — assertions that are hard to satisfy without actually doing the work correctly. Think about what makes an assertion *discriminating*: it passes when the skill genuinely succeeds and fails when it doesn't.
+良い提案は意味のある結果をテストする — スキルが正しく成功したときにパスし、失敗したときにフェイルするアサーション。アサーションを*識別的*にするものを考える。
 
-Suggestions worth raising:
-- An assertion that passed but would also pass for a clearly wrong output (e.g., checking filename existence but not file content)
-- An important outcome you observed — good or bad — that no assertion covers at all
-- An assertion that can't actually be verified from the available outputs
+提起する価値のある提案:
+- パスしたが明らかに誤った出力でもパスするアサーション（例: ファイルの存在確認だがコンテンツ確認なし）
+- どのアサーションもカバーしていない、観察した重要な結果（良い・悪い両方）
+- 利用可能な出力から実際には検証できないアサーション
 
-Keep the bar high. The goal is to flag things the eval author would say "good catch" about, not to nitpick every assertion.
+基準を高く保つ。evalの作者が「良い指摘だ」と言うものをフラグするのが目標であり、すべてのアサーションにケチをつけることではない。
 
-### Step 7: Write Grading Results
+### ステップ7: グレーディング結果を書く
 
-Save results to `{outputs_dir}/../grading.json` (sibling to outputs_dir).
+結果を`{outputs_dir}/../grading.json`に保存する（outputs_dirの兄弟ディレクトリ）。
 
-## Grading Criteria
+## グレーディング基準
 
-**PASS when**:
-- The transcript or outputs clearly demonstrate the expectation is true
-- Specific evidence can be cited
-- The evidence reflects genuine substance, not just surface compliance (e.g., a file exists AND contains correct content, not just the right filename)
+**PASSとなる場合**:
+- トランスクリプトまたは出力が期待値が真であることを明確に示す
+- 具体的な証拠を引用できる
+- 証拠が真の実体を反映している（表面的なコンプライアンスではない）
 
-**FAIL when**:
-- No evidence found for the expectation
-- Evidence contradicts the expectation
-- The expectation cannot be verified from available information
-- The evidence is superficial — the assertion is technically satisfied but the underlying task outcome is wrong or incomplete
-- The output appears to meet the assertion by coincidence rather than by actually doing the work
+**FAILとなる場合**:
+- 期待値の証拠が見つからない
+- 証拠が期待値と矛盾する
+- 利用可能な情報から期待値を検証できない
+- 証拠が表面的 — アサーションが技術的には満たされているが、基礎となるタスク結果が誤っているか不完全
+- 出力が実際に作業をせずに偶然アサーションを満たしている
 
-**When uncertain**: The burden of proof to pass is on the expectation.
+**不確かな場合**: PASSの証明責任は期待値にある。
 
-### Step 8: Read Executor Metrics and Timing
+### ステップ8: エグゼキューターのメトリクスとタイミングを読む
 
-1. If `{outputs_dir}/metrics.json` exists, read it and include in grading output
-2. If `{outputs_dir}/../timing.json` exists, read it and include timing data
+1. `{outputs_dir}/metrics.json`が存在する場合、読んでグレーディング出力に含める
+2. `{outputs_dir}/../timing.json`が存在する場合、読んでタイミングデータを含める
 
-## Output Format
+## 出力フォーマット
 
-Write a JSON file with this structure:
+以下の構造でJSONファイルを書く:
 
 ```json
 {
   "expectations": [
     {
-      "text": "The output includes the name 'John Smith'",
+      "text": "出力に 'John Smith' という名前が含まれている",
       "passed": true,
-      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+      "evidence": "トランスクリプトのステップ3で発見: '抽出された名前: John Smith, Sarah Johnson'"
     },
     {
-      "text": "The spreadsheet has a SUM formula in cell B10",
+      "text": "スプレッドシートのセルB10にSUM数式がある",
       "passed": false,
-      "evidence": "No spreadsheet was created. The output was a text file."
+      "evidence": "スプレッドシートは作成されなかった。出力はテキストファイルだった。"
     },
     {
-      "text": "The assistant used the skill's OCR script",
+      "text": "アシスタントがスキルのOCRスクリプトを使用した",
       "passed": true,
-      "evidence": "Transcript Step 2 shows: 'Tool: Bash - python ocr_script.py image.png'"
+      "evidence": "トランスクリプトのステップ2で示す: 'Tool: Bash - python ocr_script.py image.png'"
     }
   ],
   "summary": {
@@ -151,73 +151,73 @@ Write a JSON file with this structure:
   },
   "claims": [
     {
-      "claim": "The form has 12 fillable fields",
+      "claim": "フォームには12の記入可能なフィールドがある",
       "type": "factual",
       "verified": true,
-      "evidence": "Counted 12 fields in field_info.json"
+      "evidence": "field_info.jsonで12のフィールドを確認"
     },
     {
-      "claim": "All required fields were populated",
+      "claim": "すべての必須フィールドが記入された",
       "type": "quality",
       "verified": false,
-      "evidence": "Reference section was left blank despite data being available"
+      "evidence": "データが利用可能にもかかわらず、参照セクションが空白のまま"
     }
   ],
   "user_notes_summary": {
-    "uncertainties": ["Used 2023 data, may be stale"],
+    "uncertainties": ["2023年のデータを使用、古い可能性がある"],
     "needs_review": [],
-    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+    "workarounds": ["記入不可フィールドにテキストオーバーレイでフォールバック"]
   },
   "eval_feedback": {
     "suggestions": [
       {
-        "assertion": "The output includes the name 'John Smith'",
-        "reason": "A hallucinated document that mentions the name would also pass — consider checking it appears as the primary contact with matching phone and email from the input"
+        "assertion": "出力に 'John Smith' という名前が含まれている",
+        "reason": "名前を言及する幻覚されたドキュメントもパスする — 入力からの一致する電話番号とメールを持つ主連絡先として表示されることを確認することを検討する"
       },
       {
-        "reason": "No assertion checks whether the extracted phone numbers match the input — I observed incorrect numbers in the output that went uncaught"
+        "reason": "抽出された電話番号が入力と一致するか確認するアサーションがない — 出力で見つかった不正確な番号が見逃された"
       }
     ],
-    "overall": "Assertions check presence but not correctness. Consider adding content verification."
+    "overall": "アサーションは存在を確認するが正確性は確認しない。コンテンツ検証の追加を検討する。"
   }
 }
 ```
 
-## Field Descriptions
+## フィールドの説明
 
-- **expectations**: Array of graded expectations
-  - **text**: The original expectation text
-  - **passed**: Boolean - true if expectation passes
-  - **evidence**: Specific quote or description supporting the verdict
-- **summary**: Aggregate statistics
-  - **passed**: Count of passed expectations
-  - **failed**: Count of failed expectations
-  - **total**: Total expectations evaluated
-  - **pass_rate**: Fraction passed (0.0 to 1.0)
-- **execution_metrics**: Copied from executor's metrics.json (if available)
-  - **output_chars**: Total character count of output files (proxy for tokens)
-  - **transcript_chars**: Character count of transcript
-- **timing**: Wall clock timing from timing.json (if available)
-  - **executor_duration_seconds**: Time spent in executor subagent
-  - **total_duration_seconds**: Total elapsed time for the run
-- **claims**: Extracted and verified claims from the output
-  - **claim**: The statement being verified
-  - **type**: "factual", "process", or "quality"
-  - **verified**: Boolean - whether the claim holds
-  - **evidence**: Supporting or contradicting evidence
-- **user_notes_summary**: Issues flagged by the executor
-  - **uncertainties**: Things the executor wasn't sure about
-  - **needs_review**: Items requiring human attention
-  - **workarounds**: Places where the skill didn't work as expected
-- **eval_feedback**: Improvement suggestions for the evals (only when warranted)
-  - **suggestions**: List of concrete suggestions, each with a `reason` and optionally an `assertion` it relates to
-  - **overall**: Brief assessment — can be "No suggestions, evals look solid" if nothing to flag
+- **expectations**: グレードされた期待値の配列
+  - **text**: 元の期待値テキスト
+  - **passed**: ブール値 — 期待値がパスする場合はtrue
+  - **evidence**: 判定を支持する具体的な引用または説明
+- **summary**: 集計統計
+  - **passed**: パスした期待値の数
+  - **failed**: フェイルした期待値の数
+  - **total**: 評価した期待値の総数
+  - **pass_rate**: パス割合（0.0〜1.0）
+- **execution_metrics**: エグゼキューターのmetrics.jsonからコピー（利用可能な場合）
+  - **output_chars**: 出力ファイルの総文字数（トークンの代替指標）
+  - **transcript_chars**: トランスクリプトの文字数
+- **timing**: timing.jsonからのウォールクロックタイミング（利用可能な場合）
+  - **executor_duration_seconds**: エグゼキューターサブエージェントで費やした時間
+  - **total_duration_seconds**: 実行の総経過時間
+- **claims**: 出力から抽出して検証した主張
+  - **claim**: 検証される陳述
+  - **type**: "factual"、"process"、または "quality"
+  - **verified**: ブール値 — 主張が成立するか
+  - **evidence**: 支持または矛盾する証拠
+- **user_notes_summary**: エグゼキューターがフラグした問題
+  - **uncertainties**: エグゼキューターが確信を持てなかった事項
+  - **needs_review**: 人間の注意が必要な項目
+  - **workarounds**: スキルが期待通りに機能しなかった箇所
+- **eval_feedback**: evalの改善提案（該当する場合のみ）
+  - **suggestions**: 具体的な提案のリスト、各提案には`reason`と任意で関連する`assertion`を含む
+  - **overall**: 簡潔な評価 — フラグすることがない場合は「提案なし、evalは良好です」でも可
 
-## Guidelines
+## ガイドライン
 
-- **Be objective**: Base verdicts on evidence, not assumptions
-- **Be specific**: Quote the exact text that supports your verdict
-- **Be thorough**: Check both transcript and output files
-- **Be consistent**: Apply the same standard to each expectation
-- **Explain failures**: Make it clear why evidence was insufficient
-- **No partial credit**: Each expectation is pass or fail, not partial
+- **客観的に**: 推測ではなく証拠に基づいて判定する
+- **具体的に**: 判定を支持する正確なテキストを引用する
+- **徹底的に**: トランスクリプトと出力ファイルの両方を確認する
+- **一貫性を持つ**: 各期待値に同じ基準を適用する
+- **失敗を説明する**: 証拠が不十分だった理由を明確にする
+- **部分点なし**: 各期待値はパスまたはフェイル、部分的ではない

--- a/.claude/skills/skill-creator/references/description-optimization.md
+++ b/.claude/skills/skill-creator/references/description-optimization.md
@@ -1,50 +1,50 @@
-# Description Optimization
+# 説明文の最適化
 
-The `description` field in SKILL.md frontmatter is the primary mechanism determining whether Claude invokes a skill. Optimize it after the skill itself is in good shape — not before.
+SKILL.mdフロントマターの`description`フィールドは、Claudeがスキルを呼び出すかどうかを決定する主要なメカニズム。スキル自体が良好な状態になった後に最適化する — それ以前は不可。
 
-## How skill triggering works
+## スキルトリガーの仕組み
 
-Skills appear in Claude's `available_skills` list with name + description. Claude consults a skill only when it can't easily handle the task alone — simple one-step queries ("read this PDF") may not trigger even with a perfect description. Your eval queries need to be complex enough that Claude would genuinely benefit from consulting a skill.
+スキルはClaudeの`available_skills`リストにname + descriptionで表示される。Claudeは一人でタスクを簡単に処理できない場合にのみスキルを参照する — シンプルな一ステップのクエリ（「このPDFを読んで」）は完璧な説明文があってもトリガーされない可能性がある。evalクエリはClaudeがスキルを参照することで本当に恩恵を受けるほど複雑でなければならない。
 
-## Step 1: Generate trigger eval queries
+## ステップ1: トリガーevalクエリを生成する
 
-Create 20 queries — a mix of should-trigger and should-not-trigger. Save as JSON:
+20件のクエリを作成する — トリガーすべきとすべきでないものを混在させる。JSONとして保存する:
 
 ```json
 [
-  {"query": "the user prompt", "should_trigger": true},
-  {"query": "another prompt", "should_trigger": false}
+  {"query": "ユーザープロンプト", "should_trigger": true},
+  {"query": "別のプロンプト", "should_trigger": false}
 ]
 ```
 
-Queries must be realistic and specific. Include file paths, company names, personal context, abbreviations, typos, casual speech. Mix lengths. Focus on edge cases — the user will review them.
+クエリは現実的で具体的でなければならない。ファイルパス、会社名、個人的な文脈、略語、タイポ、カジュアルな話し方を含める。長さを混在させる。エッジケースに注目する — ユーザーが確認する。
 
-**Should-trigger (8-10):** Different phrasings of the same intent (formal and casual). Include cases where the user doesn't name the skill explicitly but clearly needs it. Include uncommon use cases and cases where this skill competes with another.
+**トリガーすべき（8〜10件）:** 同じ意図の異なる言い回し（フォーマルとカジュアル）。ユーザーがスキルを明示的に指定しないが明らかに必要とするケースを含める。あまり一般的でない使用例や、このスキルが別のスキルと競合するケースも含める。
 
-**Should-not-trigger (8-10):** Near-misses — queries sharing keywords with the skill but actually needing something different. Adjacent domains, ambiguous phrasing, same concepts in a context where another tool wins. Don't make these obviously irrelevant — that doesn't test anything.
+**トリガーすべきでない（8〜10件）:** ニアミス — スキルとキーワードを共有するが実際には別のものが必要なクエリ。隣接するドメイン、曖昧な言い回し、別のツールが勝つコンテキストの同じ概念。明らかに無関係なものにしない — それは何もテストしない。
 
-**Bad:** `"Format this data"`, `"Extract text from PDF"`, `"Create a chart"`
+**悪い例:** `"このデータをフォーマットして"`、`"PDFからテキストを抽出して"`、`"グラフを作成して"`
 
-**Good:** `"ok so my boss just sent me this xlsx file (its in my downloads, called something like 'Q4 sales final FINAL v2.xlsx') and she wants me to add a column that shows the profit margin as a percentage. The revenue is in column C and costs are in column D i think"`
+**良い例:** `"上司がxlsxファイルを送ってきた（ダウンロードフォルダに'Q4 sales final FINAL v2.xlsx'みたいな名前で）、利益率をパーセントで表示する列を追加したいって。収益は列Cで、コストはたぶん列Dだと思う"`
 
-## Step 2: Review with user
+## ステップ2: ユーザーと確認する
 
-1. Read the template from `assets/eval_review.html`
-2. Replace placeholders:
-   - `__EVAL_DATA_PLACEHOLDER__` → the JSON array (no quotes — it's a JS variable assignment)
-   - `__SKILL_NAME_PLACEHOLDER__` → skill name
-   - `__SKILL_DESCRIPTION_PLACEHOLDER__` → current description
-3. Write to `/tmp/eval_review_<skill-name>.html` and open: `open /tmp/eval_review_<skill-name>.html`
-4. User edits queries, toggles should-trigger, adds/removes entries, clicks "Export Eval Set"
-5. Check `~/Downloads/` for `eval_set.json` (grab the most recent if there are duplicates)
+1. `assets/eval_review.html`からテンプレートを読む
+2. プレースホルダーを置き換える:
+   - `__EVAL_DATA_PLACEHOLDER__` → JSON配列（引用符なし — JS変数の代入）
+   - `__SKILL_NAME_PLACEHOLDER__` → スキル名
+   - `__SKILL_DESCRIPTION_PLACEHOLDER__` → 現在の説明文
+3. `/tmp/eval_review_<skill-name>.html`に書き込んで開く: `open /tmp/eval_review_<skill-name>.html`
+4. ユーザーがクエリを編集し、トリガーを切り替え、エントリを追加・削除し、「Eval Setをエクスポート」をクリックする
+5. `~/Downloads/`で`eval_set.json`を確認する（複数ある場合は最新を取得）
 
-This step matters — bad eval queries produce bad descriptions.
+このステップは重要 — 悪いevalクエリは悪い説明文を生む。
 
-## Step 3: Run the optimization loop
+## ステップ3: 最適化ループを実行する
 
-Tell the user: "This will take some time — I'll run it in the background and check in periodically."
+ユーザーに伝える: 「これには時間がかかります — バックグラウンドで実行して定期的に状況をお知らせします。」
 
-Save the eval set to the workspace, then run:
+eval setをワークスペースに保存してから実行する:
 
 ```bash
 python -m scripts.run_loop \
@@ -55,12 +55,12 @@ python -m scripts.run_loop \
   --verbose
 ```
 
-Use the model ID from your system prompt — the triggering test should match what the user actually experiences.
+システムプロンプトのモデルIDを使用する — トリガーテストはユーザーが実際に体験するものと一致すべき。
 
-The loop automatically: splits 60% train / 40% held-out test, evaluates the current description (3 runs per query for reliability), uses extended thinking to propose improvements based on failures, re-evaluates, iterates up to 5 times. Returns `best_description` selected by test score (not train score, to avoid overfitting).
+ループは自動的に: 60%トレーニング / 40%ホールドアウトテストに分割、現在の説明文を評価（信頼性のためにクエリごとに3回実行）、失敗に基づいて拡張思考で改善を提案、再評価、最大5回イテレーション。過適合を避けるためにトレーニングスコアではなくテストスコアで選ばれた`best_description`を返す。
 
-Periodically tail the output to give the user progress updates.
+ユーザーに進捗更新を伝えるために定期的に出力をtailする。
 
-## Step 4: Apply the result
+## ステップ4: 結果を適用する
 
-Take `best_description` from the JSON output. Update SKILL.md frontmatter. Show the user before/after and report the scores.
+JSON出力から`best_description`を取得する。SKILL.mdフロントマターを更新する。前後を比較してスコアを報告する。

--- a/.claude/skills/skill-creator/references/improving-skill.md
+++ b/.claude/skills/skill-creator/references/improving-skill.md
@@ -1,38 +1,38 @@
-# Improving the Skill
+# スキルの改善
 
-This is the heart of the loop. You've run tests, the user has reviewed results — now make the skill better.
+これはループの核心部分。テストを実行し、ユーザーが結果を確認した — 今、スキルをより良くする。
 
-## How to think about improvements
+## 改善の考え方
 
-**1. Generalize from the feedback.**
-You're iterating on a handful of examples, but the skill will run across millions of different prompts. Don't make overfitty changes tuned to specific test cases. If something is stubbornly wrong, try a completely different framing — a different metaphor, a different pattern of working. It's cheap to try and you might land on something great.
+**1. フィードバックから一般化する。**
+いくつかのサンプルでイテレーションしているが、スキルは何百万もの異なるプロンプトで実行される。特定のテストケースに合わせたオーバーフィットな変更をしない。何かが頑固に間違っている場合、まったく異なるフレーミングを試す — 異なるメタファー、異なる作業パターン。試すのは安価で、素晴らしいものを見つけるかもしれない。
 
-**2. Keep it lean.**
-Read the transcripts, not just the final outputs. If the skill is making the model spend time on unproductive steps, find the instruction driving that behavior and remove or rephrase it. Every token in SKILL.md costs something every time the skill runs. Remove anything that isn't clearly pulling its weight.
+**2. スリムに保つ。**
+最終出力だけでなくトランスクリプトを読む。スキルがモデルに非生産的なステップに時間を費やさせている場合、その動作を引き起こしている指示を見つけて削除または言い換える。SKILL.md内のすべてのトークンは、スキルが実行されるたびにコストがかかる。明らかに機能していないものはすべて削除する。
 
-**3. Explain the why.**
-LLMs reason better when they understand purpose. If you catch yourself writing "ALWAYS" or "NEVER" in all caps, that's a signal: step back and explain *why* that behavior matters instead. Instructions with reasoning behind them generalize better than rigid rules. More humane and more effective.
+**3. なぜを説明する。**
+LLMは目的を理解したときに推論がより良くなる。「ALWAYS」や「NEVER」を大文字で書いていたら、それはシグナル: 一歩引いて、その動作がなぜ重要かを代わりに説明する。背後に推論がある指示は、硬直したルールよりも良く一般化する。より人道的で、より効果的。
 
-**4. Bundle repeated work.**
-Read the subagent transcripts across all test cases. If every run independently wrote the same `create_docx.py` or `build_chart.py`, that script belongs in `scripts/`. Write it once, bundle it, and save every future invocation from reinventing the wheel.
+**4. 繰り返し作業をバンドルする。**
+すべてのテストケースのサブエージェントトランスクリプトを読む。すべての実行が独立して同じ`create_docx.py`や`build_chart.py`を書いていたら、そのスクリプトは`scripts/`に属する。一度書いて、バンドルして、将来のすべての呼び出しで車輪を再発明することを節約する。
 
-Take time here. Draft a revision, then set it down and read it fresh before finalizing. Really get into the head of the user.
+ここで時間をかける。改訂版を草案し、一度置いて新鮮な目で読み直してから確定する。ユーザーの立場になって考える。
 
-## The iteration loop
+## イテレーションループ
 
-1. Apply your improvements to the skill
-2. Rerun all test cases into `iteration-<N+1>/`, including baseline runs
-   - **New skill**: baseline is always `without_skill` (no skill)
-   - **Improving existing skill**: use the original version the user came in with as baseline, or the previous iteration — your judgment based on what's most informative
-3. Launch the eval viewer with `--previous-workspace <workspace>/iteration-<N>`
-4. Wait for the user to review and say they're done
-5. Read the new `feedback.json`, improve, repeat
+1. スキルに改善を適用する
+2. すべてのテストケースを`iteration-<N+1>/`に再実行する（ベースライン実行を含む）
+   - **新しいスキル**: ベースラインは常に`without_skill`（スキルなし）
+   - **既存スキルの改善**: ユーザーが最初に持ってきたオリジナルバージョンまたは前のイテレーションをベースラインとして使用する — 何が最も有益かによる判断
+3. `--previous-workspace <workspace>/iteration-<N>`でevalビューアーを起動する
+4. ユーザーが確認して完了と言うのを待つ
+5. 新しい`feedback.json`を読み、改善して繰り返す
 
-Keep going until:
-- The user says they're happy
-- All feedback entries are empty (everything looked good)
-- You're not making meaningful progress
+以下の場合まで続ける:
+- ユーザーが満足と言う
+- すべてのフィードバックエントリが空（すべてが良く見えた）
+- 意味のある進歩ができていない
 
-## Advanced: Blind comparison
+## 上級: ブラインド比較
 
-For more rigorous version comparison ("is the new version actually better?"), read `agents/comparator.md` and `agents/analyzer.md`. An independent subagent judges two outputs without knowing which is which. Optional — the human review loop is usually sufficient.
+バージョン比較をより厳密に行うために（「新しいバージョンは本当に良くなっているか？」）、`agents/comparator.md`と`agents/analyzer.md`を読む。独立したサブエージェントがどちらがどちらか知らずに2つの出力を判断する。オプション — 人間のレビューループで通常は十分。

--- a/.claude/skills/skill-creator/references/platform-specific.md
+++ b/.claude/skills/skill-creator/references/platform-specific.md
@@ -1,35 +1,35 @@
-# Platform-Specific Instructions
+# プラットフォーム固有の指示
 
 ## Claude.ai
 
-No subagents available. Adapt the workflow:
+サブエージェントは利用不可。ワークフローを適応させる:
 
-**Running test cases:** Read the skill's SKILL.md, then follow its instructions to complete the test prompt yourself, one at a time. You wrote the skill and you're running it, so you have full context — less rigorous than independent subagents, but the human review step compensates. Skip baseline runs.
+**テストケースの実行:** スキルのSKILL.mdを読み、その指示に従ってテストプロンプトを一度に一つ自分で実行する。スキルを書いて実行しているので完全なコンテキストがある — 独立したサブエージェントほど厳密ではないが、人間のレビューステップが補完する。ベースライン実行をスキップする。
 
-**Reviewing results:** Can't open a browser. Present results directly in conversation — show each prompt and its output. For file outputs (.docx, .xlsx), save to the filesystem and tell the user the path to download it. Ask for feedback inline: "How does this look? Anything you'd change?"
+**結果の確認:** ブラウザを開けない。会話内で直接結果を提示する — 各プロンプトとその出力を表示する。ファイル出力（.docx、.xlsx）の場合、ファイルシステムに保存してユーザーにダウンロードパスを伝える。インラインでフィードバックを求める: 「これはどう見えますか？変更したいことはありますか？」
 
-**Benchmarking:** Skip — relies on baseline comparisons that aren't meaningful without subagents.
+**ベンチマーク:** スキップ — サブエージェントなしでは意味のないベースライン比較に依存している。
 
-**Iteration loop:** Same as main workflow, but without the browser reviewer. Organize results in iteration directories if a filesystem is available.
+**イテレーションループ:** メインワークフローと同じだが、ブラウザレビューなし。ファイルシステムが利用可能な場合、イテレーションディレクトリに結果を整理する。
 
-**Description optimization:** Requires `claude -p` CLI (Claude Code only). Skip.
+**説明文の最適化:** `claude -p` CLI（Claude Codeのみ）が必要。スキップする。
 
-**Blind comparison:** Requires subagents. Skip.
+**ブラインド比較:** サブエージェントが必要。スキップする。
 
-**Packaging:** `python -m scripts.package_skill <skill-path>` works anywhere with Python. User can download the `.skill` file.
+**パッケージ化:** `python -m scripts.package_skill <skill-path>`はPythonがあればどこでも動作する。ユーザーが`.skill`ファイルをダウンロードできる。
 
 ---
 
 ## Cowork
 
-Subagents work. Browser doesn't.
+サブエージェントは動作する。ブラウザは動作しない。
 
-**Eval viewer:** Use `--static <output_path>` to write a standalone HTML file instead of starting a server. Provide the path as a link the user can click. The "Submit All Reviews" button downloads `feedback.json` — you may need to request access before reading it.
+**Evalビューアー:** サーバーを起動する代わりに`--static <output_path>`を使用してスタンドアロンHTMLファイルを書き込む。ユーザーがクリックできるリンクとしてパスを提供する。「すべてのレビューを送信」ボタンで`feedback.json`をダウンロードする — 読む前にアクセスのリクエストが必要な場合がある。
 
-**Generate the eval viewer before evaluating inputs yourself.** Cowork environments tend to skip this step — don't. Use `generate_review.py`, not custom HTML. Get results in front of the human before making any revisions.
+**入力を自分で評価する前にevalビューアーを生成する。** Cowork環境はこのステップをスキップしがちだが、しないこと。`generate_review.py`を使用し、カスタムHTMLは使用しない。改訂を行う前に結果を人間の前に置く。
 
-**Description optimization:** `run_loop.py` works fine via subprocess. Save it until the skill is fully in good shape.
+**説明文の最適化:** `run_loop.py`はサブプロセス経由で正常に動作する。スキルが完全に良好な状態になるまで保留する。
 
-**Packaging:** Works normally.
+**パッケージ化:** 通常通り動作する。
 
-**Timeouts:** If parallel subagent runs hit timeouts, it's OK to run test prompts in series rather than parallel.
+**タイムアウト:** 並列サブエージェント実行がタイムアウトに達した場合、直列でテストプロンプトを実行しても良い。

--- a/.claude/skills/skill-creator/references/running-evals.md
+++ b/.claude/skills/skill-creator/references/running-evals.md
@@ -1,50 +1,50 @@
-# Running and Evaluating Test Cases
+# テストケースの実行と評価
 
-This is a continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
+これは連続したシーケンスであり、途中で止めてはいけない。`/skill-test`や他のテストスキルは使用しない。
 
-Put results in `<skill-name>-workspace/` as a sibling to the skill directory. Organize by iteration (`iteration-1/`, `iteration-2/`, etc.), and within each iteration, one directory per test case. Create directories as you go — don't create everything upfront.
+結果はスキルディレクトリの兄弟として`<skill-name>-workspace/`に保存する。イテレーションごとに整理し（`iteration-1/`、`iteration-2/`など）、各イテレーション内にテストケースごとのディレクトリを作成する。事前にすべてを作成せず、進めながら作成する。
 
-## Step 1: Spawn all runs in the same turn
+## ステップ1: 同じターンですべての実行を起動する
 
-For each test case, spawn two subagents in parallel — one with the skill, one without. Launch everything at once. Subagents run in isolated (forked) contexts, so they don't accumulate tokens in the main conversation — use this to keep the main context lean.
+各テストケースについて、スキルありとスキルなしの2つのサブエージェントを並列で起動する。すべてを一度に起動する。サブエージェントは独立した（フォーク）コンテキストで実行されるため、メイン会話のトークンを消費しない — これを活用してメインコンテキストをスリムに保つ。
 
-**With-skill run:**
+**スキルありの実行:**
 
 ```
-Execute this task:
-- Skill path: <path-to-skill>
-- Task: <eval prompt>
-- Input files: <eval files if any, or "none">
-- Save outputs to: <workspace>/iteration-<N>/<eval-name>/with_skill/outputs/
-- Outputs to save: <what the user cares about — e.g., "the .docx file", "the final CSV">
+このタスクを実行してください:
+- スキルパス: <path-to-skill>
+- タスク: <eval prompt>
+- 入力ファイル: <eval files if any, or "none">
+- 出力先: <workspace>/iteration-<N>/<eval-name>/with_skill/outputs/
+- 保存する出力: <ユーザーが重視するもの — 例: ".docxファイル"、"最終CSV">
 ```
 
-**Baseline run** (same prompt, context adjusted):
-- **New skill**: no skill at all. Save to `without_skill/outputs/`.
-- **Improving existing skill**: snapshot first (`cp -r <skill-path> <workspace>/skill-snapshot/`), point baseline at the snapshot. Save to `old_skill/outputs/`.
+**ベースライン実行**（同じプロンプト、コンテキストを調整）:
+- **新しいスキル**: スキルなし。`without_skill/outputs/`に保存。
+- **既存スキルの改善**: まずスナップショット（`cp -r <skill-path> <workspace>/skill-snapshot/`）、ベースラインをスナップショットに向ける。`old_skill/outputs/`に保存。
 
-Write `eval_metadata.json` for each test case (assertions can be empty for now). Use descriptive names based on what the eval is testing:
+各テストケースに`eval_metadata.json`を書く（アサーションは今は空でよい）。テストしている内容に基づいた説明的な名前を使用する:
 
 ```json
 {
   "eval_id": 0,
   "eval_name": "descriptive-name-here",
-  "prompt": "The user's task prompt",
+  "prompt": "ユーザーのタスクプロンプト",
   "assertions": []
 }
 ```
 
-## Step 2: Draft assertions while runs are in progress
+## ステップ2: 実行中にアサーションを草案する
 
-Don't wait — use this time productively. Draft quantitative assertions for each test case and explain them to the user. Good assertions are objectively verifiable and have clear names readable at a glance in the benchmark viewer. Subjective skills (writing style, design quality) don't need forced assertions — qualitative human review is better.
+待たずに — この時間を有効に使う。各テストケースの定量的アサーションを草案し、ユーザーに説明する。良いアサーションは客観的に検証可能で、ベンチマークビューアーで一目でわかる明確な名前を持つ。主観的なスキル（文体、デザイン品質）にはアサーションを無理に設ける必要はない — 定性的な人間のレビューの方が優れている。
 
-Update `eval_metadata.json` and `evals/evals.json` with assertions. See `references/schemas.md` for the full schema.
+`eval_metadata.json`と`evals/evals.json`をアサーションで更新する。完全なスキーマは`references/schemas.md`を参照。
 
-Also explain to the user what they'll see in the viewer.
+また、ユーザーがビューアーで何を見るか説明する。
 
-## Step 3: Capture timing data as runs complete
+## ステップ3: 実行完了時にタイミングデータを取得する
 
-When each subagent finishes, you get a notification with `total_tokens` and `duration_ms`. Save it immediately — this is the only chance to capture it:
+各サブエージェントが完了すると、`total_tokens`と`duration_ms`を含む通知が届く。すぐに保存する — これが取得できる唯一の機会:
 
 ```json
 {
@@ -54,29 +54,29 @@ When each subagent finishes, you get a notification with `total_tokens` and `dur
 }
 ```
 
-Save to `timing.json` in the run directory. Process each notification as it arrives.
+実行ディレクトリの`timing.json`に保存する。各通知が届いたらすぐに処理する。
 
-## Step 4: Grade, aggregate, and launch the viewer
+## ステップ4: グレーディング、集計、ビューアーの起動
 
-**Grade each run** — spawn a grader subagent pointing at `agents/grader.md`. Save results to `grading.json`. The viewer requires these exact field names:
+**各実行をグレードする** — `agents/grader.md`を指すグレーダーサブエージェントを起動する。結果を`grading.json`に保存する。ビューアーはこれらの正確なフィールド名を必要とする:
 
 ```json
-{"text": "assertion description", "passed": true, "evidence": "why it passed or failed"}
+{"text": "アサーションの説明", "passed": true, "evidence": "パスまたはフェイルした理由"}
 ```
 
-For programmatic checks, write a script — faster, more reliable, reusable.
+プログラムによる確認には、スクリプトを書く — より速く、より信頼性が高く、再利用可能。
 
-**Aggregate:**
+**集計:**
 
 ```bash
 python -m scripts.aggregate_benchmark <workspace>/iteration-N --skill-name <name>
 ```
 
-Produces `benchmark.json` and `benchmark.md`. Put with_skill before baseline in ordering.
+`benchmark.json`と`benchmark.md`を生成する。順序ではwith_skillをベースラインの前に置く。
 
-**Analyst pass** — read `agents/analyzer.md` to surface patterns the aggregate stats might hide: non-discriminating assertions (always pass regardless of skill), high-variance evals (possibly flaky), time/token tradeoffs.
+**アナリストパス** — `agents/analyzer.md`を読んで集計統計が隠すパターンを浮き彫りにする: 識別しないアサーション（スキルに関係なく常にパス）、高分散eval（不安定な可能性）、時間・トークンのトレードオフ。
 
-**Launch the viewer:**
+**ビューアーを起動する:**
 
 ```bash
 nohup python <skill-creator-path>/eval-viewer/generate_review.py \
@@ -87,38 +87,38 @@ nohup python <skill-creator-path>/eval-viewer/generate_review.py \
 VIEWER_PID=$!
 ```
 
-For iteration 2+: add `--previous-workspace <workspace>/iteration-<N-1>`.
+イテレーション2以降: `--previous-workspace <workspace>/iteration-<N-1>`を追加する。
 
-**Headless / Cowork environments:** Use `--static <output_path>` instead of starting a server. The "Submit All Reviews" button downloads `feedback.json`.
+**ヘッドレス / Cowork環境:** サーバーを起動する代わりに`--static <output_path>`を使用する。「すべてのレビューを送信」ボタンで`feedback.json`をダウンロードする。
 
-**Generate the eval viewer before evaluating inputs yourself.** Get results in front of the human first — then improve based on their actual feedback, not your own assessment.
+**入力を自分で評価する前にevalビューアーを生成する。** まず人間の前に結果を置く — その後、自分の評価ではなく実際のフィードバックに基づいて改善する。
 
-Tell the user: "I've opened the results in your browser. 'Outputs' tab lets you review each test case and leave feedback; 'Benchmark' tab shows the quantitative comparison. Come back when you're done."
+ユーザーに伝える: 「ブラウザで結果を開きました。'Outputs'タブで各テストケースを確認してフィードバックを残せます；'Benchmark'タブで定量的な比較が見られます。終わったら戻ってきてください。」
 
-### What the user sees
+### ユーザーが見るもの
 
-**Outputs tab**: prompt, output files (rendered inline where possible), previous output (iteration 2+, collapsed), assertion grades (collapsed), feedback textbox, previous feedback (iteration 2+).
+**Outputsタブ**: プロンプト、出力ファイル（可能な場合はインラインでレンダリング）、前の出力（イテレーション2以降、折りたたみ）、アサーションのグレード（折りたたみ）、フィードバックテキストボックス、前のフィードバック（イテレーション2以降）。
 
-**Benchmark tab**: pass rates, timing, token usage per configuration, with per-eval breakdowns and analyst notes.
+**Benchmarkタブ**: パス率、タイミング、設定ごとのトークン使用量、eval別の詳細とアナリストのメモ。
 
-Navigation: prev/next buttons or arrow keys. "Submit All Reviews" saves to `feedback.json`.
+ナビゲーション: 前・次ボタンまたは矢印キー。「すべてのレビューを送信」で`feedback.json`に保存。
 
-## Step 5: Read the feedback
+## ステップ5: フィードバックを読む
 
 ```json
 {
   "reviews": [
-    {"run_id": "eval-0-with_skill", "feedback": "chart missing axis labels"},
+    {"run_id": "eval-0-with_skill", "feedback": "チャートに軸ラベルがない"},
     {"run_id": "eval-1-with_skill", "feedback": ""},
-    {"run_id": "eval-2-with_skill", "feedback": "perfect, love this"}
+    {"run_id": "eval-2-with_skill", "feedback": "完璧、これが好き"}
   ],
   "status": "complete"
 }
 ```
 
-Empty feedback = satisfied. Focus improvements on specific complaints.
+空のフィードバック = 満足。具体的な不満に改善を集中させる。
 
-Kill the viewer server when done:
+完了したらビューアーサーバーを終了する:
 
 ```bash
 kill $VIEWER_PID 2>/dev/null

--- a/.claude/skills/skill-creator/references/schemas.md
+++ b/.claude/skills/skill-creator/references/schemas.md
@@ -1,12 +1,12 @@
-# JSON Schemas
+# JSONスキーマ
 
-This document defines the JSON schemas used by skill-creator.
+このドキュメントはskill-creatorが使用するJSONスキーマを定義する。
 
 ---
 
 ## evals.json
 
-Defines the evals for a skill. Located at `evals/evals.json` within the skill directory.
+スキルのevalを定義する。スキルディレクトリ内の`evals/evals.json`に配置する。
 
 ```json
 {
@@ -14,31 +14,31 @@ Defines the evals for a skill. Located at `evals/evals.json` within the skill di
   "evals": [
     {
       "id": 1,
-      "prompt": "User's example prompt",
-      "expected_output": "Description of expected result",
+      "prompt": "ユーザーのサンプルプロンプト",
+      "expected_output": "期待される結果の説明",
       "files": ["evals/files/sample1.pdf"],
       "expectations": [
-        "The output includes X",
-        "The skill used script Y"
+        "出力にXが含まれている",
+        "スキルがスクリプトYを使用した"
       ]
     }
   ]
 }
 ```
 
-**Fields:**
-- `skill_name`: Name matching the skill's frontmatter
-- `evals[].id`: Unique integer identifier
-- `evals[].prompt`: The task to execute
-- `evals[].expected_output`: Human-readable description of success
-- `evals[].files`: Optional list of input file paths (relative to skill root)
-- `evals[].expectations`: List of verifiable statements
+**フィールド:**
+- `skill_name`: スキルのフロントマターと一致する名前
+- `evals[].id`: 一意の整数識別子
+- `evals[].prompt`: 実行するタスク
+- `evals[].expected_output`: 成功の人間が読める説明
+- `evals[].files`: 入力ファイルパスのオプションリスト（スキルルートからの相対パス）
+- `evals[].expectations`: 検証可能な陳述のリスト
 
 ---
 
 ## history.json
 
-Tracks version progression in Improve mode. Located at workspace root.
+Improveモードでのバージョン進行を追跡する。ワークスペースルートに配置する。
 
 ```json
 {
@@ -71,34 +71,34 @@ Tracks version progression in Improve mode. Located at workspace root.
 }
 ```
 
-**Fields:**
-- `started_at`: ISO timestamp of when improvement started
-- `skill_name`: Name of the skill being improved
-- `current_best`: Version identifier of the best performer
-- `iterations[].version`: Version identifier (v0, v1, ...)
-- `iterations[].parent`: Parent version this was derived from
-- `iterations[].expectation_pass_rate`: Pass rate from grading
-- `iterations[].grading_result`: "baseline", "won", "lost", or "tie"
-- `iterations[].is_current_best`: Whether this is the current best version
+**フィールド:**
+- `started_at`: 改善開始時のISOタイムスタンプ
+- `skill_name`: 改善中のスキルの名前
+- `current_best`: 最高パフォーマーのバージョン識別子
+- `iterations[].version`: バージョン識別子（v0、v1、...）
+- `iterations[].parent`: このバージョンの派生元の親バージョン
+- `iterations[].expectation_pass_rate`: グレーディングのパス率
+- `iterations[].grading_result`: "baseline"、"won"、"lost"、または "tie"
+- `iterations[].is_current_best`: これが現在の最良バージョンかどうか
 
 ---
 
 ## grading.json
 
-Output from the grader agent. Located at `<run-dir>/grading.json`.
+グレーダーエージェントの出力。`<run-dir>/grading.json`に配置する。
 
 ```json
 {
   "expectations": [
     {
-      "text": "The output includes the name 'John Smith'",
+      "text": "出力に 'John Smith' という名前が含まれている",
       "passed": true,
-      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+      "evidence": "トランスクリプトのステップ3で発見: '抽出された名前: John Smith, Sarah Johnson'"
     },
     {
-      "text": "The spreadsheet has a SUM formula in cell B10",
+      "text": "スプレッドシートのセルB10にSUM数式がある",
       "passed": false,
-      "evidence": "No spreadsheet was created. The output was a text file."
+      "evidence": "スプレッドシートは作成されなかった。出力はテキストファイルだった。"
     }
   ],
   "summary": {
@@ -126,43 +126,43 @@ Output from the grader agent. Located at `<run-dir>/grading.json`.
   },
   "claims": [
     {
-      "claim": "The form has 12 fillable fields",
+      "claim": "フォームには12の記入可能なフィールドがある",
       "type": "factual",
       "verified": true,
-      "evidence": "Counted 12 fields in field_info.json"
+      "evidence": "field_info.jsonで12のフィールドを確認"
     }
   ],
   "user_notes_summary": {
-    "uncertainties": ["Used 2023 data, may be stale"],
+    "uncertainties": ["2023年のデータを使用、古い可能性がある"],
     "needs_review": [],
-    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+    "workarounds": ["記入不可フィールドにテキストオーバーレイでフォールバック"]
   },
   "eval_feedback": {
     "suggestions": [
       {
-        "assertion": "The output includes the name 'John Smith'",
-        "reason": "A hallucinated document that mentions the name would also pass"
+        "assertion": "出力に 'John Smith' という名前が含まれている",
+        "reason": "名前を言及する幻覚されたドキュメントもパスする"
       }
     ],
-    "overall": "Assertions check presence but not correctness."
+    "overall": "アサーションは存在を確認するが正確性は確認しない。"
   }
 }
 ```
 
-**Fields:**
-- `expectations[]`: Graded expectations with evidence
-- `summary`: Aggregate pass/fail counts
-- `execution_metrics`: Tool usage and output size (from executor's metrics.json)
-- `timing`: Wall clock timing (from timing.json)
-- `claims`: Extracted and verified claims from the output
-- `user_notes_summary`: Issues flagged by the executor
-- `eval_feedback`: (optional) Improvement suggestions for the evals, only present when the grader identifies issues worth raising
+**フィールド:**
+- `expectations[]`: 証拠付きのグレードされた期待値
+- `summary`: 集計パス/フェイル数
+- `execution_metrics`: ツール使用量と出力サイズ（エグゼキューターのmetrics.jsonから）
+- `timing`: ウォールクロックタイミング（timing.jsonから）
+- `claims`: 出力から抽出して検証した主張
+- `user_notes_summary`: エグゼキューターがフラグした問題
+- `eval_feedback`: （オプション）evalの改善提案、グレーダーが問題を特定した場合のみ存在
 
 ---
 
 ## metrics.json
 
-Output from the executor agent. Located at `<run-dir>/outputs/metrics.json`.
+エグゼキューターエージェントの出力。`<run-dir>/outputs/metrics.json`に配置する。
 
 ```json
 {
@@ -183,22 +183,22 @@ Output from the executor agent. Located at `<run-dir>/outputs/metrics.json`.
 }
 ```
 
-**Fields:**
-- `tool_calls`: Count per tool type
-- `total_tool_calls`: Sum of all tool calls
-- `total_steps`: Number of major execution steps
-- `files_created`: List of output files created
-- `errors_encountered`: Number of errors during execution
-- `output_chars`: Total character count of output files
-- `transcript_chars`: Character count of transcript
+**フィールド:**
+- `tool_calls`: ツールタイプごとのカウント
+- `total_tool_calls`: すべてのツール呼び出しの合計
+- `total_steps`: 主要な実行ステップの数
+- `files_created`: 作成された出力ファイルのリスト
+- `errors_encountered`: 実行中のエラー数
+- `output_chars`: 出力ファイルの総文字数
+- `transcript_chars`: トランスクリプトの文字数
 
 ---
 
 ## timing.json
 
-Wall clock timing for a run. Located at `<run-dir>/timing.json`.
+実行のウォールクロックタイミング。`<run-dir>/timing.json`に配置する。
 
-**How to capture:** When a subagent task completes, the task notification includes `total_tokens` and `duration_ms`. Save these immediately — they are not persisted anywhere else and cannot be recovered after the fact.
+**取得方法:** サブエージェントタスクが完了すると、タスク通知に`total_tokens`と`duration_ms`が含まれる。すぐに保存する — これらは他の場所には保持されず、後から回収できない。
 
 ```json
 {
@@ -218,7 +218,7 @@ Wall clock timing for a run. Located at `<run-dir>/timing.json`.
 
 ## benchmark.json
 
-Output from Benchmark mode. Located at `benchmarks/<timestamp>/benchmark.json`.
+Benchmarkモードの出力。`benchmarks/<timestamp>/benchmark.json`に配置する。
 
 ```json
 {
@@ -252,8 +252,8 @@ Output from Benchmark mode. Located at `benchmarks/<timestamp>/benchmark.json`.
         {"text": "...", "passed": true, "evidence": "..."}
       ],
       "notes": [
-        "Used 2023 data, may be stale",
-        "Fell back to text overlay for non-fillable fields"
+        "2023年のデータを使用、古い可能性がある",
+        "記入不可フィールドにテキストオーバーレイでフォールバック"
       ]
     }
   ],
@@ -277,43 +277,43 @@ Output from Benchmark mode. Located at `benchmarks/<timestamp>/benchmark.json`.
   },
 
   "notes": [
-    "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
-    "Eval 3 shows high variance (50% ± 40%) - may be flaky or model-dependent",
-    "Without-skill runs consistently fail on table extraction expectations",
-    "Skill adds 13s average execution time but improves pass rate by 50%"
+    "アサーション 'Output is a PDF file' が両設定で100%パス — スキルの価値を区別しない可能性",
+    "Eval 3が高い分散を示す（50% ± 40%）— 不安定またはモデル依存の可能性",
+    "スキルなし実行がテーブル抽出の期待値で一貫して失敗",
+    "スキルが平均13秒の実行時間を追加するが、パス率を50%改善する"
   ]
 }
 ```
 
-**Fields:**
-- `metadata`: Information about the benchmark run
-  - `skill_name`: Name of the skill
-  - `timestamp`: When the benchmark was run
-  - `evals_run`: List of eval names or IDs
-  - `runs_per_configuration`: Number of runs per config (e.g. 3)
-- `runs[]`: Individual run results
-  - `eval_id`: Numeric eval identifier
-  - `eval_name`: Human-readable eval name (used as section header in the viewer)
-  - `configuration`: Must be `"with_skill"` or `"without_skill"` (the viewer uses this exact string for grouping and color coding)
-  - `run_number`: Integer run number (1, 2, 3...)
-  - `result`: Nested object with `pass_rate`, `passed`, `total`, `time_seconds`, `tokens`, `errors`
-- `run_summary`: Statistical aggregates per configuration
-  - `with_skill` / `without_skill`: Each contains `pass_rate`, `time_seconds`, `tokens` objects with `mean` and `stddev` fields
-  - `delta`: Difference strings like `"+0.50"`, `"+13.0"`, `"+1700"`
-- `notes`: Freeform observations from the analyzer
+**フィールド:**
+- `metadata`: ベンチマーク実行に関する情報
+  - `skill_name`: スキルの名前
+  - `timestamp`: ベンチマーク実行時刻
+  - `evals_run`: eval名またはIDのリスト
+  - `runs_per_configuration`: 設定ごとの実行数（例: 3）
+- `runs[]`: 個別の実行結果
+  - `eval_id`: 数値のeval識別子
+  - `eval_name`: 人間が読める名前（ビューアーのセクションヘッダーとして使用）
+  - `configuration`: 必ず`"with_skill"`または`"without_skill"`（ビューアーがこの文字列をグループ化と色分けに使用）
+  - `run_number`: 整数の実行番号（1、2、3...）
+  - `result`: `pass_rate`、`passed`、`total`、`time_seconds`、`tokens`、`errors`を含むネストされたオブジェクト
+- `run_summary`: 設定ごとの統計集計
+  - `with_skill` / `without_skill`: それぞれ`mean`と`stddev`フィールドを含む`pass_rate`、`time_seconds`、`tokens`オブジェクト
+  - `delta`: `"+0.50"`、`"+13.0"`、`"+1700"`のような差分文字列
+- `notes`: アナライザーからの自由形式の観察
 
-**Important:** The viewer reads these field names exactly. Using `config` instead of `configuration`, or putting `pass_rate` at the top level of a run instead of nested under `result`, will cause the viewer to show empty/zero values. Always reference this schema when generating benchmark.json manually.
+**重要:** ビューアーはこれらのフィールド名を正確に読む。`configuration`の代わりに`config`を使用したり、`pass_rate`を`result`の下にネストする代わりにrunのトップレベルに置いたりすると、ビューアーが空・ゼロの値を表示する原因になる。手動でbenchmark.jsonを生成する際は常にこのスキーマを参照する。
 
 ---
 
 ## comparison.json
 
-Output from blind comparator. Located at `<grading-dir>/comparison-N.json`.
+ブラインドコンパレーターの出力。`<grading-dir>/comparison-N.json`に配置する。
 
 ```json
 {
   "winner": "A",
-  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "reasoning": "出力Aは適切なフォーマットとすべての必須フィールドを含む完全なソリューションを提供する。出力Bはdateフィールドが欠落しており、フォーマットの一貫性に問題がある。",
   "rubric": {
     "A": {
       "content": {
@@ -349,13 +349,13 @@ Output from blind comparator. Located at `<grading-dir>/comparison-N.json`.
   "output_quality": {
     "A": {
       "score": 9,
-      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
-      "weaknesses": ["Minor style inconsistency in header"]
+      "strengths": ["完全なソリューション", "適切なフォーマット", "すべてのフィールドが存在"],
+      "weaknesses": ["ヘッダーのスタイルに軽微な不一致"]
     },
     "B": {
       "score": 5,
-      "strengths": ["Readable output", "Correct basic structure"],
-      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+      "strengths": ["読みやすい出力", "基本構造が正確"],
+      "weaknesses": ["dateフィールドが欠落", "フォーマットの不一致", "データ抽出が部分的"]
     }
   },
   "expectation_results": {
@@ -383,7 +383,7 @@ Output from blind comparator. Located at `<grading-dir>/comparison-N.json`.
 
 ## analysis.json
 
-Output from post-hoc analyzer. Located at `<grading-dir>/analysis.json`.
+ポストホック分析エージェントの出力。`<grading-dir>/analysis.json`に配置する。
 
 ```json
 {
@@ -391,26 +391,26 @@ Output from post-hoc analyzer. Located at `<grading-dir>/analysis.json`.
     "winner": "A",
     "winner_skill": "path/to/winner/skill",
     "loser_skill": "path/to/loser/skill",
-    "comparator_reasoning": "Brief summary of why comparator chose winner"
+    "comparator_reasoning": "コンパレーターが勝者を選んだ理由の概要"
   },
   "winner_strengths": [
-    "Clear step-by-step instructions for handling multi-page documents",
-    "Included validation script that caught formatting errors"
+    "複数ページドキュメント処理のための明確なステップバイステップの指示",
+    "フォーマットエラーを検出した検証スクリプトを含む"
   ],
   "loser_weaknesses": [
-    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
-    "No script for validation, agent had to improvise"
+    "「適切にドキュメントを処理する」という曖昧な指示が一貫性のない動作につながった",
+    "検証スクリプトがなく、エージェントが即興した"
   ],
   "instruction_following": {
     "winner": {
       "score": 9,
-      "issues": ["Minor: skipped optional logging step"]
+      "issues": ["軽微: オプションのログ記録ステップをスキップした"]
     },
     "loser": {
       "score": 6,
       "issues": [
-        "Did not use the skill's formatting template",
-        "Invented own approach instead of following step 3"
+        "スキルのフォーマットテンプレートを使用しなかった",
+        "ステップ3を無視して独自のアプローチを考案した"
       ]
     }
   },
@@ -418,13 +418,13 @@ Output from post-hoc analyzer. Located at `<grading-dir>/analysis.json`.
     {
       "priority": "high",
       "category": "instructions",
-      "suggestion": "Replace 'process the document appropriately' with explicit steps",
-      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+      "suggestion": "「適切にドキュメントを処理する」を明示的なステップに置き換える",
+      "expected_impact": "一貫性のない動作を引き起こした曖昧さを排除できる"
     }
   ],
   "transcript_insights": {
-    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script",
-    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods"
+    "winner_execution_pattern": "スキル読み込み -> 5ステップのプロセスに従う -> 検証スクリプト使用",
+    "loser_execution_pattern": "スキル読み込み -> アプローチが不明確 -> 3つの異なる方法を試行"
   }
 }
 ```


### PR DESCRIPTION
closes #282

skill-creatorスキルの全ファイル（9ファイル）を日本語に翻訳しました。

Generated with [Claude Code](https://claude.ai/code)