### PR TITLE
feat: コントロールバーのWebインタラクションを改善する

### DIFF
--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -552,6 +552,12 @@ body {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: 6px;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.ctrl-label-toggle:hover {
+  color: var(--gold);
+  border-color: var(--gold);
 }
 
 .ctrl-checkbox {
@@ -594,6 +600,11 @@ body {
   min-width: 7rem;
   text-align: left;
   appearance: auto;
+}
+
+.substat-dropdown-btn:hover {
+  color: var(--gold);
+  border-color: var(--gold);
 }
 
 .substat-dropdown-btn:focus {

--- a/webapp/src/components/ControlsBar.tsx
+++ b/webapp/src/components/ControlsBar.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom'
 import type { ArtifactSlotKey, ReconstructionType, ScoreTypeName, StatKey } from '@/lib/types'
 import type { ArtifactFiltersHook } from '@/hooks/useArtifactFilters'
 import { useDropdownClose } from '@/hooks/useDropdownClose'
+import { useDropdownPosition } from '@/hooks/useDropdownPosition'
 import { hasActiveFilter } from '@/lib/filterUtils'
 import { ARTIFACT_SET_NAMES, MAIN_STAT_NAMES, STAT_NAMES, SCORE_TYPE_OPTIONS, ALL_SUBSTAT_KEYS } from '@/lib/constants'
 import type { Translations } from '@/lib/i18n/types'
@@ -50,6 +51,9 @@ export default function ControlsBar({
   const subStatPanelRef = useRef<HTMLDivElement>(null)
   const setFilterBtnRef = useRef<HTMLButtonElement>(null)
   const setFilterPanelRef = useRef<HTMLDivElement>(null)
+
+  const subStatPos = useDropdownPosition(subStatBtnRef, subStatOpen)
+  const setFilterPos = useDropdownPosition(setFilterBtnRef, setFilterOpen)
 
   useDropdownClose([
     {
@@ -146,6 +150,8 @@ export default function ControlsBar({
                 ref={setFilterBtnRef}
                 type="button"
                 className={`substat-dropdown-btn${filters.filterSets.length > 0 ? ' ctrl-active' : ''}`}
+                aria-expanded={setFilterOpen}
+                aria-haspopup="listbox"
                 onClick={() => setSetFilterOpen((v) => !v)}
               >
                 {filters.filterSets.length > 0
@@ -157,8 +163,8 @@ export default function ControlsBar({
                   ref={setFilterPanelRef}
                   className="set-dropdown-panel"
                   style={{
-                    top: (setFilterBtnRef.current?.getBoundingClientRect().bottom ?? 0) + 4,
-                    left: setFilterBtnRef.current?.getBoundingClientRect().left ?? 0,
+                    top: setFilterPos.top,
+                    left: setFilterPos.left,
                   }}
                 >
                   {setOptionGroups.map((group) => {
@@ -267,6 +273,8 @@ export default function ControlsBar({
                   ref={subStatBtnRef}
                   type="button"
                   className={`substat-dropdown-btn${filters.filterSubStats.length > 0 ? ' ctrl-active' : ''}`}
+                  aria-expanded={subStatOpen}
+                  aria-haspopup="listbox"
                   onClick={() => setSubStatOpen((v) => !v)}
                 >
                   {filters.filterSubStats.length > 0
@@ -278,8 +286,8 @@ export default function ControlsBar({
                     ref={subStatPanelRef}
                     className="substat-dropdown-panel"
                     style={{
-                      top: (subStatBtnRef.current?.getBoundingClientRect().bottom ?? 0) + 4,
-                      left: subStatBtnRef.current?.getBoundingClientRect().left ?? 0,
+                      top: subStatPos.top,
+                      left: subStatPos.left,
                     }}
                   >
                     {availableSubStatKeys.map((key) => (

--- a/webapp/src/hooks/useDropdownPosition.ts
+++ b/webapp/src/hooks/useDropdownPosition.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+
+interface DropdownPosition {
+  top: number
+  left: number
+}
+
+/**
+ * ボタンの画面上の位置を追跡し、スクロール・リサイズ時に更新するフック。
+ * ポータル経由でドロップダウンパネルを配置する際の位置計算に使用する。
+ * @param btnRef 対象ボタンのref
+ * @param open ドロップダウンが開いているか
+ */
+export function useDropdownPosition(
+  btnRef: { current: Element | null },
+  open: boolean,
+): DropdownPosition {
+  const [pos, setPos] = useState<DropdownPosition>({ top: 0, left: 0 })
+
+  useEffect(() => {
+    if (!open) return
+
+    function update() {
+      const rect = btnRef.current?.getBoundingClientRect()
+      if (rect) {
+        setPos({ top: rect.bottom + 4, left: rect.left })
+      }
+    }
+
+    update()
+    window.addEventListener('scroll', update, true)
+    window.addEventListener('resize', update)
+    return () => {
+      window.removeEventListener('scroll', update, true)
+      window.removeEventListener('resize', update)
+    }
+  }, [open, btnRef])
+
+  return pos
+}

--- a/webapp/src/lib/__tests__/useDropdownPosition.test.ts
+++ b/webapp/src/lib/__tests__/useDropdownPosition.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { useDropdownPosition } from '@/hooks/useDropdownPosition'
+
+const makeBtnRef = (bottom: number, left: number) => ({
+  current: {
+    getBoundingClientRect: () => ({
+      bottom,
+      left,
+      top: bottom - 30,
+      right: left + 80,
+      width: 80,
+      height: 30,
+    }),
+  } as unknown as Element,
+})
+
+describe('useDropdownPosition', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('open=false のとき top/left は 0 のまま', () => {
+    const btnRef = makeBtnRef(100, 200)
+    const { result } = renderHook(() => useDropdownPosition(btnRef, false))
+    expect(result.current.top).toBe(0)
+    expect(result.current.left).toBe(0)
+  })
+
+  it('open=true のとき bottom+4 を top、left をそのまま返す', () => {
+    const btnRef = makeBtnRef(100, 200)
+    const { result } = renderHook(() => useDropdownPosition(btnRef, true))
+    expect(result.current.top).toBe(104)
+    expect(result.current.left).toBe(200)
+  })
+
+  it('open=true のときスクロールイベントで位置が更新される', () => {
+    const btnRef = makeBtnRef(100, 200)
+    const { result } = renderHook(() => useDropdownPosition(btnRef, true))
+    expect(result.current.top).toBe(104)
+
+    // スクロール後にボタン位置が変わった場合をシミュレート
+    ;(btnRef.current as unknown as { getBoundingClientRect: () => Partial<DOMRect> }).getBoundingClientRect =
+      () => ({ bottom: 50, left: 200 })
+
+    act(() => {
+      window.dispatchEvent(new Event('scroll'))
+    })
+
+    expect(result.current.top).toBe(54)
+  })
+
+  it('open=true のときリサイズイベントで位置が更新される', () => {
+    const btnRef = makeBtnRef(100, 200)
+    const { result } = renderHook(() => useDropdownPosition(btnRef, true))
+
+    ;(btnRef.current as unknown as { getBoundingClientRect: () => Partial<DOMRect> }).getBoundingClientRect =
+      () => ({ bottom: 80, left: 300 })
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'))
+    })
+
+    expect(result.current.top).toBe(84)
+    expect(result.current.left).toBe(300)
+  })
+
+  it('アンマウント時にイベントリスナーが削除される', () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+    const btnRef = makeBtnRef(100, 200)
+
+    const { unmount } = renderHook(() => useDropdownPosition(btnRef, true))
+    unmount()
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('scroll', expect.any(Function), true)
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
+  })
+
+  it('open が false に変わるとイベントリスナーが削除される', () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+    const btnRef = makeBtnRef(100, 200)
+
+    const { rerender } = renderHook(
+      ({ open }: { open: boolean }) => useDropdownPosition(btnRef, open),
+      { initialProps: { open: true } },
+    )
+
+    rerender({ open: false })
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('scroll', expect.any(Function), true)
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
+  })
+})


### PR DESCRIPTION
Closes #288

## 変更内容

- `useDropdownPosition` フックを新規作成し、ドロップダウンパネルの位置をスクロール・リサイズ時に動的に追跡
- `ControlsBar` にフックを適用し、ポータルドロップダウンの位置ずれを修正
- ドロップダウンボタンに `aria-expanded` ・ `aria-haspopup` を追加
- `substat-dropdown-btn` と `ctrl-label-toggle` にホバースタイルを追加

Generated with [Claude Code](https://claude.ai/code)