### PR TITLE
test(e2e): add Playwright E2E test scenarios for home, artifact-card, sidebar

### DIFF
--- a/webapp/e2e/artifact-card.spec.ts
+++ b/webapp/e2e/artifact-card.spec.ts
@@ -1,0 +1,90 @@
+import path from 'path'
+import { test, expect } from '@playwright/test'
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'test-good.json')
+
+test.describe('聖遺物カード', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.locator('input[type="file"]').setInputFiles(FIXTURE_PATH)
+    await page.waitForSelector('.controls-bar', { state: 'visible' })
+  })
+
+  test('カードが表示される', async ({ page }) => {
+    const card = page.locator('.artifact-card').first()
+    await expect(card).toBeVisible()
+  })
+
+  test('スコアセクションが表示される', async ({ page }) => {
+    const card = page.locator('.artifact-card').first()
+    await expect(card.locator('.score-section')).toBeVisible()
+    await expect(card.locator('.main-score')).toBeVisible()
+  })
+
+  test('スコアランクバッジ（S/A/B/C）が表示される', async ({ page }) => {
+    const card = page.locator('.artifact-card').first()
+    const badge = card.locator('.score-rank-badge')
+    await expect(badge).toBeVisible()
+    const text = await badge.textContent()
+    expect(['S', 'A', 'B', 'C']).toContain(text?.trim())
+  })
+
+  test('サブステ行が1行以上表示される', async ({ page }) => {
+    const card = page.locator('.artifact-card').first()
+    const substats = card.locator('.substat-row')
+    expect(await substats.count()).toBeGreaterThan(0)
+  })
+
+  test('サブステ行には名前と値が表示される', async ({ page }) => {
+    const card = page.locator('.artifact-card').first()
+    const firstSubstat = card.locator('.substat-row').first()
+    await expect(firstSubstat.locator('.substat-name')).toBeVisible()
+    await expect(firstSubstat.locator('.substat-value')).toBeVisible()
+  })
+
+  test('スコアバーが表示される', async ({ page }) => {
+    const card = page.locator('.artifact-card').first()
+    await expect(card.locator('.score-bar-wrap')).toBeVisible()
+    await expect(card.locator('.score-bar')).toBeVisible()
+  })
+
+  test('聖遺物画像エリアをクリックするとコンテキストメニューが表示される', async ({ page }) => {
+    const card = page.locator('.artifact-card').first()
+    const imgWrap = card.locator('.artifact-img-clickable')
+
+    // クリック可能な場合のみテスト
+    const count = await imgWrap.count()
+    if (count === 0) {
+      // クリック不可コンポーネントはスキップ
+      return
+    }
+
+    await imgWrap.click()
+    await expect(page.locator('.context-menu')).toBeVisible()
+  })
+
+  test('コンテキストメニューは画面外クリックで閉じる', async ({ page }) => {
+    const card = page.locator('.artifact-card').first()
+    const imgWrap = card.locator('.artifact-img-clickable')
+
+    const count = await imgWrap.count()
+    if (count === 0) return
+
+    await imgWrap.click()
+    await expect(page.locator('.context-menu')).toBeVisible()
+
+    // 画面外（メインコンテナ）をクリックして閉じる
+    await page.locator('.main-container').click({ position: { x: 5, y: 5 } })
+    await expect(page.locator('.context-menu')).not.toBeVisible()
+  })
+
+  test('再構築成功率バッジが表示されている場合は数値が含まれる', async ({ page }) => {
+    const reconBadge = page.locator('.recon-rate-badge').first()
+    const count = await reconBadge.count()
+    if (count === 0) return // 再構築成功率なしの場合はスキップ
+
+    await expect(reconBadge).toBeVisible()
+    const text = await reconBadge.textContent()
+    expect(text).toMatch(/\d+%/)
+  })
+})

--- a/webapp/e2e/home.spec.ts
+++ b/webapp/e2e/home.spec.ts
@@ -1,0 +1,108 @@
+import path from 'path'
+import { test, expect } from '@playwright/test'
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'test-good.json')
+
+test.describe('ホームページ — 初期状態（ファイルアップロード前）', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+  })
+
+  test('ヒーローセクションが表示される', async ({ page }) => {
+    await expect(page.locator('.hero-section')).toBeVisible()
+  })
+
+  test('アップロードゾーンが表示される', async ({ page }) => {
+    await expect(page.locator('.upload-zone')).toBeVisible()
+    await expect(page.locator('input[type="file"]')).toBeAttached()
+  })
+
+  test('スコア式カードグリッドが表示される', async ({ page }) => {
+    const grid = page.locator('.score-card-grid')
+    await expect(grid).toBeVisible()
+    // スコア式カードが複数存在する
+    const cards = grid.locator('.score-formula-card')
+    await expect(cards).toHaveCount(await cards.count())
+    expect(await cards.count()).toBeGreaterThan(0)
+  })
+
+  test('スコア式カードをクリックするとアクティブ状態に切り替わる', async ({ page }) => {
+    const firstCard = page.locator('.score-formula-card').first()
+    await firstCard.click()
+    await expect(firstCard).toHaveClass(/score-formula-card-active/)
+
+    // 再クリックで非アクティブに戻る
+    await firstCard.click()
+    await expect(firstCard).not.toHaveClass(/score-formula-card-active/)
+  })
+
+  test('コントロールバーはアップロード前は非表示', async ({ page }) => {
+    await expect(page.locator('.controls-bar')).not.toBeVisible()
+  })
+})
+
+test.describe('ホームページ — ファイルアップロード後', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    const fileInput = page.locator('input[type="file"]')
+    await fileInput.setInputFiles(FIXTURE_PATH)
+    await page.waitForSelector('.controls-bar', { state: 'visible' })
+  })
+
+  test('コントロールバーが表示される', async ({ page }) => {
+    await expect(page.locator('.controls-bar')).toBeVisible()
+  })
+
+  test('聖遺物カードが1枚以上表示される', async ({ page }) => {
+    const cards = page.locator('.artifact-card')
+    await expect(cards.first()).toBeVisible()
+    expect(await cards.count()).toBeGreaterThan(0)
+  })
+
+  test('ヒーローセクションは非表示になる', async ({ page }) => {
+    await expect(page.locator('.hero-section')).not.toBeVisible()
+  })
+
+  test('部位フィルタで flower を選択するとカードが絞り込まれる', async ({ page }) => {
+    const allCount = await page.locator('.artifact-card').count()
+
+    const slotSelect = page.locator('.controls-bar .ctrl-select').nth(0)
+    await slotSelect.selectOption('flower')
+
+    const filteredCount = await page.locator('.artifact-card').count()
+    expect(filteredCount).toBeGreaterThan(0)
+    expect(filteredCount).toBeLessThanOrEqual(allCount)
+  })
+
+  test('部位フィルタをリセットするとチップが消える', async ({ page }) => {
+    const slotSelect = page.locator('.controls-bar .ctrl-select').nth(0)
+    await slotSelect.selectOption('flower')
+
+    // フィルタチップが現れる
+    await expect(page.locator('.ctrl-filter-chips')).toBeVisible()
+
+    // 全件表示に戻す
+    await slotSelect.selectOption('')
+    await expect(page.locator('.ctrl-filter-chips')).not.toBeVisible()
+  })
+
+  test('フィルタチップの × ボタンで絞り込みが解除される', async ({ page }) => {
+    const slotSelect = page.locator('.controls-bar .ctrl-select').nth(0)
+    await slotSelect.selectOption('flower')
+
+    // チップの × をクリック
+    const chip = page.locator('.ctrl-filter-chip').first()
+    await chip.click()
+
+    await expect(page.locator('.ctrl-filter-chips')).not.toBeVisible()
+  })
+
+  test('スコアタイプを切り替えるとカードに反映される', async ({ page }) => {
+    const scoreSelect = page.locator('.controls-bar .ctrl-select').first()
+    // 攻撃型以外に切り替え
+    await scoreSelect.selectOption('CV')
+    // カードが表示され続ける
+    await expect(page.locator('.artifact-card').first()).toBeVisible()
+  })
+})

--- a/webapp/e2e/sidebar.spec.ts
+++ b/webapp/e2e/sidebar.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('サイドバー — ナビゲーション', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+  })
+
+  test('サイドバーが表示される', async ({ page }) => {
+    await expect(page.locator('.sidebar')).toBeVisible()
+  })
+
+  test('ナビゲーションリンクが1件以上存在する', async ({ page }) => {
+    const links = page.locator('.sidebar-link')
+    expect(await links.count()).toBeGreaterThan(0)
+  })
+
+  test('about-score ページへ遷移できる', async ({ page }) => {
+    const link = page.locator('.sidebar-link[href*="about-score"]')
+    await expect(link).toBeVisible()
+    await link.click()
+    await expect(page).toHaveURL(/about-score/)
+  })
+
+  test('about-reconstruction ページへ遷移できる', async ({ page }) => {
+    const link = page.locator('.sidebar-link[href*="about-reconstruction"]')
+    await expect(link).toBeVisible()
+    await link.click()
+    await expect(page).toHaveURL(/about-reconstruction/)
+  })
+
+  test('how-to-use ページへ遷移できる', async ({ page }) => {
+    const link = page.locator('.sidebar-link[href*="how-to-use"]')
+    await expect(link).toBeVisible()
+    await link.click()
+    await expect(page).toHaveURL(/how-to-use/)
+  })
+
+  test('faq ページへ遷移できる', async ({ page }) => {
+    const link = page.locator('.sidebar-link[href*="faq"]')
+    await expect(link).toBeVisible()
+    await link.click()
+    await expect(page).toHaveURL(/faq/)
+  })
+
+  test('disclaimer ページへ遷移できる', async ({ page }) => {
+    const link = page.locator('.sidebar-link[href*="disclaimer"]')
+    await expect(link).toBeVisible()
+    await link.click()
+    await expect(page).toHaveURL(/disclaimer/)
+  })
+
+  test('現在のページのリンクに active クラスが付与される', async ({ page }) => {
+    // about-score へ遷移
+    await page.locator('.sidebar-link[href*="about-score"]').click()
+    await expect(page).toHaveURL(/about-score/)
+    await expect(page.locator('.sidebar-link-active')).toBeVisible()
+  })
+})
+
+test.describe('サイドバー — 言語切替', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+  })
+
+  test('言語切替ボタンが EN と JA の2つ表示される', async ({ page }) => {
+    await expect(page.locator('button.lang-btn:has-text("JA")')).toBeVisible()
+    await expect(page.locator('button.lang-btn:has-text("EN")')).toBeVisible()
+  })
+
+  test('JA ボタンをクリックすると日本語に切り替わる', async ({ page }) => {
+    await page.locator('button.lang-btn:has-text("JA")').click()
+    await expect(
+      page.locator('button.lang-btn:has-text("JA")[aria-pressed="true"]'),
+    ).toBeVisible()
+  })
+
+  test('EN ボタンをクリックすると英語に切り替わる', async ({ page }) => {
+    // まず JA に切り替え
+    await page.locator('button.lang-btn:has-text("JA")').click()
+    // EN に戻す
+    await page.locator('button.lang-btn:has-text("EN")').click()
+    await expect(
+      page.locator('button.lang-btn:has-text("EN")[aria-pressed="true"]'),
+    ).toBeVisible()
+  })
+
+  test('言語設定が localStorage に保存され、リロード後も維持される', async ({ page }) => {
+    await page.locator('button.lang-btn:has-text("JA")').click()
+    await expect(
+      page.locator('button.lang-btn:has-text("JA")[aria-pressed="true"]'),
+    ).toBeVisible()
+
+    // ページリロード
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+
+    // JA が維持されている
+    await expect(
+      page.locator('button.lang-btn:has-text("JA")[aria-pressed="true"]'),
+    ).toBeVisible({ timeout: 5000 })
+  })
+})


### PR DESCRIPTION
Closes #291

Playwright E2E テストシナリオを 3 ファイル追加しました。

- `home.spec.ts`: ホームページの初期状態・アップロードフロー・フィルター操作
- `artifact-card.spec.ts`: 聖遺物カードのレンダリング・スコアバッジ・コンテキストメニュー
- `sidebar.spec.ts`: ナビゲーションリンク遷移・アクティブ状態・言語切替永続化

Generated with [Claude Code](https://claude.ai/code)