### PR TITLE
perf: フォントプリロードを有効化してLCP/FCPを改善する

### DIFF
--- a/webapp/src/app/layout.tsx
+++ b/webapp/src/app/layout.tsx
@@ -4,8 +4,18 @@ import './globals.css'
 import Sidebar from '@/components/Sidebar'
 import { LanguageProvider } from '@/lib/i18n'
 
-const notoSansJP = Noto_Sans_JP({
-  weight: ['400', '600', '700'],
+// weight: 400 のみプリロード対象（LCP/FCP改善のため）
+const notoSansJPRegular = Noto_Sans_JP({
+  weight: ['400'],
+  subsets: ['latin'],
+  preload: true,
+  variable: '--font-noto-sans-jp',
+  display: 'swap',
+})
+
+// 600/700 はプリロード対象外（初期表示に不要なため）
+const notoSansJPBold = Noto_Sans_JP({
+  weight: ['600', '700'],
   subsets: ['latin'],
   preload: false,
   variable: '--font-noto-sans-jp',
@@ -23,7 +33,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="ja" className={notoSansJP.variable}>
+    <html lang="ja" className={`${notoSansJPRegular.variable} ${notoSansJPBold.variable}`}>
       <head>
         <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" />
 <meta name="referrer" content="no-referrer" />


### PR DESCRIPTION
Noto Sans JP の weight: 400 のみを preload: true に変更し、FCP/LCPを改善する。

Closes #307

Generated with [Claude Code](https://claude.ai/code)