### PR TITLE
perf: 仮想スクロールによる大量データ表示の最適化

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -8,6 +8,7 @@
       "name": "webapp",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.13.21",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -2212,6 +2213,33 @@
         "@tailwindcss/oxide": "4.2.1",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.1"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.21.tgz",
+      "integrity": "sha512-SYXFrmrbPgXBvf+HsOsKhFgqSe4M6B29VHOsX9Jih9TlNkNkDWx0hWMiMLUghMEzyUz772ndzdEeCEBx+3GIZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.21"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.21.tgz",
+      "integrity": "sha512-ww+fmLHyCbPSf7JNbWZP3g7wl6SdNo3ah5Aiw+0e9FDErkVHLKprYUrwTm7dF646FtEkN/KkAKPYezxpmvOjxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,6 +14,7 @@
     "screenshot": "playwright test --config=playwright.screenshot.config.ts"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "^3.13.21",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/webapp/src/components/HomeClient.tsx
+++ b/webapp/src/components/HomeClient.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import ArtifactCard from '@/components/ArtifactCard'
 import HeroSection from '@/components/HeroSection'
+import VirtualArtifactGrid from '@/components/VirtualArtifactGrid'
 import ControlsBar from '@/components/ControlsBar'
 import type { GoodFile, MainStatKey, ReconstructionType, ScoreTypeName, StatKey } from '@/lib/types'
 import { groupSetOptions, SCORE_TYPE_OPTIONS, ALL_SUBSTAT_KEYS } from '@/lib/constants'
@@ -111,20 +111,14 @@ export default function HomeClient() {
             allMainStatNames={allMainStatNames}
           />
 
-          <div key={gridAnimKey} className="card-grid">
-            {displayed.map(({ entry, reconRate, originalIndex }, idx) => (
-              <ArtifactCard
-                key={originalIndex}
-                entry={entry}
-                scoreType={scoreType}
-                reconRate={reconRate}
-                onFilterBySet={(setKey) => filters.setFilterSets([setKey])}
-                onFilterBySlot={filters.setFilterSlot}
-                equippedSetKeys={equippedSetsMap.get(entry.artifact.location) ?? []}
-                cardIndex={idx}
-              />
-            ))}
-          </div>
+          <VirtualArtifactGrid
+            key={gridAnimKey}
+            displayed={displayed}
+            scoreType={scoreType}
+            equippedSetsMap={equippedSetsMap}
+            onFilterBySet={(setKey) => filters.setFilterSets([setKey])}
+            onFilterBySlot={filters.setFilterSlot}
+          />
         </>
       )}
     </>

--- a/webapp/src/components/VirtualArtifactGrid.tsx
+++ b/webapp/src/components/VirtualArtifactGrid.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useRef, useMemo, useEffect, useState } from 'react'
+import { useWindowVirtualizer } from '@tanstack/react-virtual'
+import ArtifactCard from '@/components/ArtifactCard'
+import type { ScoreTypeName, ArtifactSlotKey } from '@/lib/types'
+import type { DisplayedEntry } from '@/hooks/useDisplayedArtifacts'
+
+// カード最小幅とギャップ（card-grid の minmax(320px, 1fr) + gap: 1rem に合わせる）
+const CARD_MIN_WIDTH = 320
+const CARD_GAP = 16
+// 行の推定高さ（カード本体 + ギャップ）
+const ESTIMATED_ROW_HEIGHT = 300
+
+interface VirtualArtifactGridProps {
+  displayed: DisplayedEntry[]
+  scoreType: ScoreTypeName
+  equippedSetsMap: Map<string, string[]>
+  onFilterBySet: (setKey: string) => void
+  onFilterBySlot: (slotKey: ArtifactSlotKey) => void
+}
+
+/** 仮想スクロール対応のアーティファクトグリッド */
+export default function VirtualArtifactGrid({
+  displayed,
+  scoreType,
+  equippedSetsMap,
+  onFilterBySet,
+  onFilterBySlot,
+}: VirtualArtifactGridProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [columnCount, setColumnCount] = useState(3)
+  const [scrollMargin, setScrollMargin] = useState(0)
+
+  // コンテナ幅からカラム数を計算（CSS auto-fill minmax(320px,1fr) を再現）
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    const updateLayout = () => {
+      const width = el.getBoundingClientRect().width
+      const cols = Math.max(1, Math.floor((width + CARD_GAP) / (CARD_MIN_WIDTH + CARD_GAP)))
+      setColumnCount(cols)
+      setScrollMargin(el.getBoundingClientRect().top + window.scrollY)
+    }
+
+    updateLayout()
+    const resizeObserver = new ResizeObserver(updateLayout)
+    resizeObserver.observe(el)
+    window.addEventListener('scroll', updateLayout, { passive: true })
+
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('scroll', updateLayout)
+    }
+  }, [])
+
+  // アイテムを行単位にグルーピング
+  const rows = useMemo(() => {
+    const result: DisplayedEntry[][] = []
+    for (let i = 0; i < displayed.length; i += columnCount) {
+      result.push(displayed.slice(i, i + columnCount))
+    }
+    return result
+  }, [displayed, columnCount])
+
+  const virtualizer = useWindowVirtualizer({
+    count: rows.length,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    overscan: 3,
+    scrollMargin,
+  })
+
+  return (
+    <div ref={containerRef}>
+      <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const rowItems = rows[virtualRow.index]
+          const baseCardIdx = virtualRow.index * columnCount
+          return (
+            <div
+              key={virtualRow.key}
+              data-index={virtualRow.index}
+              ref={virtualizer.measureElement}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                transform: `translateY(${virtualRow.start - scrollMargin}px)`,
+                display: 'grid',
+                gridTemplateColumns: `repeat(${columnCount}, 1fr)`,
+                gap: `${CARD_GAP}px`,
+                paddingBottom: `${CARD_GAP}px`,
+              }}
+            >
+              {rowItems.map(({ entry, reconRate, originalIndex }, colIdx) => (
+                <ArtifactCard
+                  key={originalIndex}
+                  entry={entry}
+                  scoreType={scoreType}
+                  reconRate={reconRate}
+                  onFilterBySet={onFilterBySet}
+                  onFilterBySlot={onFilterBySlot}
+                  equippedSetKeys={equippedSetsMap.get(entry.artifact.location) ?? []}
+                  cardIndex={baseCardIdx + colIdx}
+                />
+              ))}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/hooks/useDisplayedArtifacts.ts
+++ b/webapp/src/hooks/useDisplayedArtifacts.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import type { RankedArtifact, ReconstructionType, ScoreTypeName, StatKey } from '@/lib/types'
 import type { ArtifactFilterState } from '@/lib/artifactFilters'
 
-interface DisplayedEntry {
+export interface DisplayedEntry {
   entry: RankedArtifact
   reconRate: number | null
   originalIndex: number


### PR DESCRIPTION
## 概要

`@tanstack/react-virtual` の `useWindowVirtualizer` を導入し、聖遺物カードグリッドを行単位で仮想化。
500件以上の聖遺物読み込み時にDOMに追加されるカード数を画面内表示分のみに抑制。

Closes #311

Generated with [Claude Code](https://claude.ai/code)