### PR TITLE
feat: UI改善 about-score・ackb-about-reconstruction 2カラムレイアウト

### DIFF
--- a/webapp/src/app/about-reconstruction/page.tsx
+++ b/webapp/src/app/about-reconstruction/page.tsx
@@ -10,62 +10,68 @@ export default function AboutReconstructionPage() {
     <div className="page-container">
       <h1 className="page-title">{p.title}</h1>
 
-      <section className="content-section">
-        <h2 className="section-title">{p.whatIs.heading}</h2>
-        <p className="content-text">{p.whatIs.p1}</p>
-        <p className="content-text">{p.whatIs.p2}</p>
-      </section>
+      <div className="page-two-col">
+        {/* 左カラム: 再構築とは + 再構築の種類 */}
+        <div className="page-col">
+          <section className="content-section">
+            <h2 className="section-title">{p.whatIs.heading}</h2>
+            <p className="content-text">{p.whatIs.p1}</p>
+            <p className="content-text">{p.whatIs.p2}</p>
+          </section>
 
-      <hr className="section-divider" />
+          <hr className="section-divider" />
 
-      <section className="content-section">
-        <h2 className="section-title">{p.types.heading}</h2>
-        <p className="content-text">{p.types.p1}</p>
-        <ul className="content-list">
-          <li><strong>{p.types.normal.split(' — ')[0]}</strong> — {p.types.normal.split(' — ')[1]}</li>
-          <li><strong>{p.types.advanced.split(' — ')[0]}</strong> — {p.types.advanced.split(' — ')[1]}</li>
-          <li><strong>{p.types.absolute.split(' — ')[0]}</strong> — {p.types.absolute.split(' — ')[1]}</li>
-        </ul>
-        <p className="content-text">{p.types.p2}</p>
-      </section>
+          <section className="content-section">
+            <h2 className="section-title">{p.types.heading}</h2>
+            <p className="content-text">{p.types.p1}</p>
+            <ul className="content-list">
+              <li><strong>{p.types.normal.split(' — ')[0]}</strong> — {p.types.normal.split(' — ')[1]}</li>
+              <li><strong>{p.types.advanced.split(' — ')[0]}</strong> — {p.types.advanced.split(' — ')[1]}</li>
+              <li><strong>{p.types.absolute.split(' — ')[0]}</strong> — {p.types.absolute.split(' — ')[1]}</li>
+            </ul>
+            <p className="content-text">{p.types.p2}</p>
+          </section>
 
-      <hr className="section-divider" />
+          <hr className="section-divider" />
 
-      <section className="content-section">
-        <h2 className="section-title">{p.successRate.heading}</h2>
-        <p className="content-text">{p.successRate.p1}</p>
-        <ol className="content-list">
-          {p.successRate.steps.map((step, i) => (
-            <li key={i}>{step}</li>
-          ))}
-        </ol>
-        <p className="content-text">{p.successRate.p2}</p>
-      </section>
+          <section className="content-section">
+            <h2 className="section-title">{p.guarantee.heading}</h2>
+            <p className="content-text">{p.guarantee.p1}</p>
+            <ul className="content-list">
+              <li><strong>{p.guarantee.basic.split(' — ')[0]}</strong> — {p.guarantee.basic.split(' — ').slice(1).join(' — ')}</li>
+              <li><strong>{p.guarantee.circlet.split(' — ')[0]}</strong> — {p.guarantee.circlet.split(' — ').slice(1).join(' — ')}</li>
+              <li><strong>{p.guarantee.cvCirclet.split(' — ')[0]}</strong> — {p.guarantee.cvCirclet.split(' — ').slice(1).join(' — ')}</li>
+            </ul>
+          </section>
+        </div>
 
-      <hr className="section-divider" />
+        {/* 右カラム: 成功率の計算方法 + 精度に関する注意事項 */}
+        <div className="page-col">
+          <section className="content-section">
+            <h2 className="section-title">{p.successRate.heading}</h2>
+            <p className="content-text">{p.successRate.p1}</p>
+            <ol className="content-list">
+              {p.successRate.steps.map((step, i) => (
+                <li key={i}>{step}</li>
+              ))}
+            </ol>
+            <p className="content-text">{p.successRate.p2}</p>
+          </section>
 
-      <section className="content-section">
-        <h2 className="section-title">{p.guarantee.heading}</h2>
-        <p className="content-text">{p.guarantee.p1}</p>
-        <ul className="content-list">
-          <li><strong>{p.guarantee.basic.split(' — ')[0]}</strong> — {p.guarantee.basic.split(' — ').slice(1).join(' — ')}</li>
-          <li><strong>{p.guarantee.circlet.split(' — ')[0]}</strong> — {p.guarantee.circlet.split(' — ').slice(1).join(' — ')}</li>
-          <li><strong>{p.guarantee.cvCirclet.split(' — ')[0]}</strong> — {p.guarantee.cvCirclet.split(' — ').slice(1).join(' — ')}</li>
-        </ul>
-      </section>
+          <hr className="section-divider" />
 
-      <hr className="section-divider" />
-
-      <section className="content-section">
-        <h2 className="section-title">{p.precision.heading}</h2>
-        <p className="content-text">{p.precision.p1}</p>
-        <ul className="content-list">
-          {p.precision.bullets.map((bullet, i) => (
-            <li key={i}>{bullet}</li>
-          ))}
-        </ul>
-        <p className="content-text">{p.precision.p2}</p>
-      </section>
+          <section className="content-section">
+            <h2 className="section-title">{p.precision.heading}</h2>
+            <p className="content-text">{p.precision.p1}</p>
+            <ul className="content-list">
+              {p.precision.bullets.map((bullet, i) => (
+                <li key={i}>{bullet}</li>
+              ))}
+            </ul>
+            <p className="content-text">{p.precision.p2}</p>
+          </section>
+        </div>
+      </div>
     </div>
   )
 }

--- a/webapp/src/app/about-score/page.tsx
+++ b/webapp/src/app/about-score/page.tsx
@@ -11,69 +11,75 @@ export default function AboutScorePage() {
     <div className="page-container">
       <h1 className="page-title">{p.title}</h1>
 
-      <section className="content-section">
-        <h2 className="section-title">{p.whatIsScore.heading}</h2>
-        <p className="content-text">{p.whatIsScore.p1}</p>
-        <p className="content-text">{p.whatIsScore.p2}</p>
-      </section>
+      <div className="page-two-col">
+        {/* 左カラム: スコアとは + CVスコア */}
+        <div className="page-col">
+          <section className="content-section">
+            <h2 className="section-title">{p.whatIsScore.heading}</h2>
+            <p className="content-text">{p.whatIsScore.p1}</p>
+            <p className="content-text">{p.whatIsScore.p2}</p>
+          </section>
 
-      <hr className="section-divider" />
+          <hr className="section-divider" />
 
-      <section className="content-section">
-        <h2 className="section-title">{p.cv.heading}</h2>
-        <p className="content-text">{p.cv.p1}</p>
-        <div className="formula-block">
-          <span className="formula-text">{p.cv.formula}</span>
+          <section className="content-section">
+            <h2 className="section-title">{p.cv.heading}</h2>
+            <p className="content-text">{p.cv.p1}</p>
+            <div className="formula-block">
+              <span className="formula-text">{p.cv.formula}</span>
+            </div>
+            <p className="content-text">{p.cv.p2}</p>
+            <div className="score-tier-list">
+              <div className="score-tier score-tier-red">{p.cv.tier55}</div>
+              <div className="score-tier score-tier-orange">{p.cv.tier45}</div>
+              <div className="score-tier score-tier-yellow">{p.cv.tier35}</div>
+              <div className="score-tier score-tier-default">{p.cv.tierDefault}</div>
+            </div>
+          </section>
         </div>
-        <p className="content-text">{p.cv.p2}</p>
-        <div className="score-tier-list">
-          <div className="score-tier score-tier-red">{p.cv.tier55}</div>
-          <div className="score-tier score-tier-orange">{p.cv.tier45}</div>
-          <div className="score-tier score-tier-yellow">{p.cv.tier35}</div>
-          <div className="score-tier score-tier-default">{p.cv.tierDefault}</div>
+
+        {/* 右カラム: スコア計算方式一覧 + メインステとスコアタイプの対応 */}
+        <div className="page-col">
+          <section className="content-section">
+            <h2 className="section-title">{p.formulaList.heading}</h2>
+            <p className="content-text">{p.formulaList.p1}</p>
+            <ul className="score-formulas-list about-formulas">
+              {SCORE_TYPE_OPTIONS.map((type) => (
+                <li key={type} className="score-formulas-item about-formulas-item">
+                  <span className="score-formulas-label">{t.scoreFormulas[type].label}</span>
+                  <span className="score-formulas-eq">=</span>
+                  <span className="score-formulas-formula">{t.scoreFormulas[type].formula}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <hr className="section-divider" />
+
+          <section className="content-section">
+            <h2 className="section-title">{p.mainStatFilter.heading}</h2>
+            <p className="content-text">{p.mainStatFilter.p1}</p>
+            <p className="content-text">{p.mainStatFilter.p2}</p>
+            <table className="info-table">
+              <thead>
+                <tr>
+                  <th>{p.mainStatFilter.tableHeaders.scoreType}</th>
+                  <th>{p.mainStatFilter.tableHeaders.mainStat}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {p.mainStatFilter.rows.map((row) => (
+                  <tr key={row.scoreType}>
+                    <td>{row.scoreType}</td>
+                    <td>{row.mainStat}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p className="content-text content-text-note">{p.mainStatFilter.note}</p>
+          </section>
         </div>
-      </section>
-
-      <hr className="section-divider" />
-
-      <section className="content-section">
-        <h2 className="section-title">{p.formulaList.heading}</h2>
-        <p className="content-text">{p.formulaList.p1}</p>
-        <ul className="score-formulas-list about-formulas">
-          {SCORE_TYPE_OPTIONS.map((type) => (
-            <li key={type} className="score-formulas-item about-formulas-item">
-              <span className="score-formulas-label">{t.scoreFormulas[type].label}</span>
-              <span className="score-formulas-eq">=</span>
-              <span className="score-formulas-formula">{t.scoreFormulas[type].formula}</span>
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <hr className="section-divider" />
-
-      <section className="content-section">
-        <h2 className="section-title">{p.mainStatFilter.heading}</h2>
-        <p className="content-text">{p.mainStatFilter.p1}</p>
-        <p className="content-text">{p.mainStatFilter.p2}</p>
-        <table className="info-table">
-          <thead>
-            <tr>
-              <th>{p.mainStatFilter.tableHeaders.scoreType}</th>
-              <th>{p.mainStatFilter.tableHeaders.mainStat}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {p.mainStatFilter.rows.map((row) => (
-              <tr key={row.scoreType}>
-                <td>{row.scoreType}</td>
-                <td>{row.mainStat}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        <p className="content-text content-text-note">{p.mainStatFilter.note}</p>
-      </section>
+      </div>
     </div>
   )
 }

--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -156,24 +156,37 @@ body {
 
 /* サイドメニューページ（スコアについて等）のコンテンツ */
 .page-container {
-  max-width: 800px;
+  max-width: 900px;
   margin: 0 auto;
-  padding: 2rem 1rem 4rem;
+  padding: 1.25rem 1rem 2rem;
   animation: page-fade-in 150ms ease-out;
 }
 
 .page-title {
   text-align: center;
-  font-size: 2rem;
+  font-size: 1.6rem;
   font-weight: 700;
   color: var(--gold);
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
   letter-spacing: 0.06em;
+}
+
+/* 2カラムページレイアウト（about-score・about-reconstruction用） */
+.page-two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.page-col {
+  display: flex;
+  flex-direction: column;
 }
 
 /* ── サイドメニューページコンテンツ ────────── */
 .content-section {
-  margin-bottom: 2rem;
+  margin-bottom: 1.25rem;
 }
 
 .section-title {
@@ -334,7 +347,7 @@ body {
   height: 1px;
   border: none;
   background: linear-gradient(90deg, transparent 0%, var(--gold) 50%, transparent 100%);
-  margin: 1.5rem 0;
+  margin: 1rem 0;
   opacity: 0.5;
 }
 


### PR DESCRIPTION
Closes #318

## 変更内容

- about-score・ackb-about-reconstruction ページを2カラムグリッドレイアウトに再構築
- 高さ900px以内にコンテンツを収めスクロール不要で全体把握できるよう改善

Generated with [Claude Code](https://claude.ai/code)